### PR TITLE
Add support for keyword arguments on filters

### DIFF
--- a/lib/liquex/argument.ex
+++ b/lib/liquex/argument.ex
@@ -20,6 +20,8 @@ defmodule Liquex.Argument do
   def eval({:inclusive_range, [begin: begin_value, end: end_value]}, context),
     do: eval(begin_value, context)..eval(end_value, context)
 
+  def eval({:keyword, [key, value]}, context), do: {key, eval(value, context)}
+
   defp do_eval(value, []), do: value
   defp do_eval(nil, _), do: nil
 

--- a/lib/liquex/parser/object.ex
+++ b/lib/liquex/parser/object.ex
@@ -15,6 +15,17 @@ defmodule Liquex.Parser.Object do
       |> ignore(string(","))
       |> ignore(Literal.whitespace())
       |> concat(Literal.argument())
+      |> lookahead_not(string(":"))
+    )
+    |> repeat(
+      ignore(Literal.whitespace())
+      |> ignore(string(","))
+      |> ignore(Literal.whitespace())
+      |> concat(Field.identifier())
+      |> ignore(string(":"))
+      |> ignore(Literal.whitespace())
+      |> concat(Literal.argument())
+      |> tag(:keyword)
     )
   end
 

--- a/test/custom/custom_filter_test.exs
+++ b/test/custom/custom_filter_test.exs
@@ -8,6 +8,9 @@ defmodule Liquex.Custom.CustomFilterTest do
     use Liquex.Filter
 
     def scream(value, _), do: String.upcase(value) <> "!"
+
+    def img_url(path, size, [{"crop", direction}, {"filter", filter}], _),
+      do: "https://example.com/#{path}?size=#{size}&crop=#{direction}&filter=#{filter}"
   end
 
   describe "custom filter" do
@@ -19,7 +22,20 @@ defmodule Liquex.Custom.CustomFilterTest do
       assert template
              |> Liquex.render(context)
              |> elem(0)
-             |> IO.chardata_to_string() == "HELLO WORLD!"
+             |> to_string() == "HELLO WORLD!"
+    end
+
+    test "handles keyword arguments" do
+      context = %Liquex.Context{filter_module: CustomFilterExample}
+
+      {:ok, template} =
+        Liquex.parse("{{'image.jpg' | img_url: '400x400', crop: 'bottom', filter: 'blur'}}")
+
+      assert template
+             |> Liquex.render(context)
+             |> elem(0)
+             |> to_string() ==
+               "https://example.com/image.jpg?size=400x400&crop=bottom&filter=blur"
     end
   end
 end

--- a/test/liquex/parser/object_test.exs
+++ b/test/liquex/parser/object_test.exs
@@ -28,6 +28,21 @@ defmodule Liquex.Parser.ObjectTest do
     )
   end
 
+  test "parses filter with key/value arguments" do
+    assert_parse(
+      "{{ product | img_url: '400x400', crop: 'bottom' }}",
+      object: [
+        field: [key: "product"],
+        filters: [
+          filter: [
+            "img_url",
+            arguments: [literal: "400x400", keyword: ["crop", literal: "bottom"]]
+          ]
+        ]
+      ]
+    )
+  end
+
   test "parses multiple filters" do
     assert_parse("{{ 'adam!' | capitalize | prepend: 'Hello ' }}",
       object: [


### PR DESCRIPTION
Follow the semi-standard from Liquid in their Shopify version where
you can use keyword arguments to filter functions.

For example:
   {{ 'image.jpg' | img_url: '400x400', crop: 'bottom' }}

See:
https://shopify.dev/docs/themes/liquid/reference/filters/url-filters#img_url