### PR TITLE
Feature/collections

### DIFF
--- a/lib/liquex/collection.ex
+++ b/lib/liquex/collection.ex
@@ -8,13 +8,69 @@ defprotocol Liquex.Collection do
   @spec reverse(t) :: t
   def reverse(collection)
 
+  @spec sort(t) :: t
+  def sort(collection)
+
+  @spec sort(t, String.t()) :: t
+  def sort(collection, field_name)
+
+  @spec sort_case_insensitive(t) :: t
+  def sort_case_insensitive(collection)
+
+  @spec sort_case_insensitive(t, String.t()) :: t
+  def sort_case_insensitive(collection, field_name)
+
+  @spec where(t, String.t()) :: t
+  def where(collection, field_name)
+
+  @spec where(t, String.t(), term) :: t
+  def where(collection, field_name, value)
+
   @spec to_enumerable(t) :: Enumerable.t()
   def to_enumerable(collection)
 end
 
 defimpl Liquex.Collection, for: [Enumerable, List, Range] do
+  @spec limit(any, integer) :: [any]
   def limit(collection, limit), do: Enum.take(collection, limit)
   def offset(collection, offset), do: Enum.drop(collection, offset)
   def reverse(collection), do: Enum.reverse(collection)
+
+  def sort(collection), do: Enum.sort(collection)
+
+  def sort(collection, field_name), do: Enum.sort_by(collection, &Map.get(&1, field_name))
+
+  def sort_case_insensitive(collection) do
+    Enum.sort_by(collection, fn
+      value when is_binary(value) -> String.downcase(value)
+      value -> value
+    end)
+  end
+
+  def sort_case_insensitive(collection, field_name) do
+    Enum.sort_by(collection, fn record ->
+      case Map.get(record, field_name) do
+        value when is_binary(value) -> String.downcase(value)
+        value -> value
+      end
+    end)
+  end
+
+  def where(collection, field_name) do
+    collection
+    |> Enum.filter(fn v ->
+      case Map.get(v, field_name) do
+        false -> false
+        nil -> false
+        _ -> true
+      end
+    end)
+  end
+
+  def where(collection, field_name, value) do
+    collection
+    |> Enum.filter(&(Map.get(&1, field_name) == value))
+  end
+
   def to_enumerable(collection), do: collection
 end

--- a/lib/liquex/filter.ex
+++ b/lib/liquex/filter.ex
@@ -586,7 +586,8 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.sort(["zebra", "octopus", "giraffe", "Sally Snake"], %{})
       ["Sally Snake", "giraffe", "octopus", "zebra"]
   """
-  def sort(list, _), do: Enum.sort(list)
+  def sort(list, _), do: Liquex.Collection.sort(list)
+  def sort(list, field_name, _), do: Liquex.Collection.sort(list, field_name)
 
   @doc """
   Sorts items in an array in case-insensitive order.
@@ -596,7 +597,10 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.sort_natural(["zebra", "octopus", "giraffe", "Sally Snake"], %{})
       ["giraffe", "octopus", "Sally Snake", "zebra"]
   """
-  def sort_natural(list, _), do: Enum.sort_by(list, &String.downcase/1)
+  def sort_natural(list, _), do: Liquex.Collection.sort_case_insensitive(list)
+
+  def sort_natural(list, field_name, _),
+    do: Liquex.Collection.sort_case_insensitive(list, field_name)
 
   @doc """
   Divides a string into an array using the argument as a separator. split is
@@ -777,10 +781,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.where([%{"b" => 2}, %{"b" => 1}], "b", 1, %{})
       [%{"b" => 1}]
   """
-  def where(map, key, value, _) do
-    map
-    |> Enum.filter(&(Map.get(&1, key) == value))
-  end
+  def where(list, key, value, _), do: Liquex.Collection.where(list, key, value)
 
   @doc """
   Creates an array including only the objects with a given truthy property value
@@ -790,14 +791,5 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.where([%{"b" => true, "value" => 1}, %{"b" => 1, "value" => 2}, %{"b" => false, "value" => 3}], "b", %{})
       [%{"b" => true, "value" => 1}, %{"b" => 1, "value" => 2}]
   """
-  def where(map, key, _) do
-    map
-    |> Enum.filter(fn v ->
-      case Map.get(v, key) do
-        false -> false
-        nil -> false
-        _ -> true
-      end
-    end)
-  end
+  def where(list, key, _), do: Liquex.Collection.where(list, key)
 end


### PR DESCRIPTION
Add filtering and sorting on collections.

When using a custom collection, allow passing filter options to the Liquex.Collection implementation.  This adds the ability to pass filters and sorts to Ecto if needed.

Fixes #3