### PR TITLE
replace to_existing_atom to to_atom

### DIFF
--- a/lib/liquex/parser/tag/control_flow.ex
+++ b/lib/liquex/parser/tag/control_flow.ex
@@ -18,7 +18,7 @@ defmodule Liquex.Parser.Tag.ControlFlow do
         string("<"),
         string("contains")
       ])
-      |> map({String, :to_existing_atom, []})
+      |> map({String, :to_atom, []})
 
     boolean_operator =
       choice([


### PR DESCRIPTION
to_atom is applied to a finit set of arguments and cannot flood memory.

Should fix issue #12 