### PR TITLE
access map fields with evaluated arguments

### DIFF
--- a/lib/liquex/argument.ex
+++ b/lib/liquex/argument.ex
@@ -50,10 +50,14 @@ defmodule Liquex.Argument do
 
   defp do_eval(value, [{:accessor, accessor} | tail]) do
     value
-    |> Enum.at(accessor)
+    |> value_at(accessor)
     |> apply_lazy(value)
     |> do_eval(tail)
   end
+
+  defp value_at(value, index) when is_map(value), do: (Enum.at(value, index) || {nil, []}) |> elem(1)
+  defp value_at(value, index) when is_list(value), do: Enum.at(value, index)
+  defp value_at(_value, _index), do: []
 
   # Apply a lazy function if needed
   defp apply_lazy(fun, _parent) when is_function(fun, 0), do: fun.()

--- a/lib/liquex/argument.ex
+++ b/lib/liquex/argument.ex
@@ -13,8 +13,8 @@ defmodule Liquex.Argument do
   @spec eval(argument_t | [argument_t], Context.t()) :: field_t
   def eval([argument], context), do: eval(argument, context)
 
-  def eval({:field, accesses}, %Context{variables: variables}),
-    do: do_eval(variables, accesses)
+  def eval({:field, accesses}, %Context{variables: variables} = context),
+    do: do_eval(variables, accesses, context)
 
   def eval({:literal, literal}, _context), do: literal
 
@@ -23,47 +23,51 @@ defmodule Liquex.Argument do
 
   def eval({:keyword, [key, value]}, context), do: {key, eval(value, context)}
 
-  defp do_eval(value, []), do: apply_lazy(value, nil)
-  defp do_eval(nil, _), do: nil
+  defp do_eval(value, [], context), do: apply_lazy(value, nil, context)
+  defp do_eval(nil, _, _context), do: nil
 
   # Special case ".first"
-  defp do_eval(value, [{:key, "first"} | tail]) when is_list(value) do
+  defp do_eval(value, [{:key, "first"} | tail], context) when is_list(value) do
     value
     |> Enum.at(0)
-    |> apply_lazy(value)
-    |> do_eval(tail)
+    |> apply_lazy(value, context)
+    |> do_eval(tail, context)
   end
 
   # Special case ".size"
-  defp do_eval(value, [{:key, "size"} | tail]) when is_list(value) do
+  defp do_eval(value, [{:key, "size"} | tail], context) when is_list(value) do
     value
     |> length()
-    |> do_eval(tail)
+    |> do_eval(tail, context)
   end
 
-  defp do_eval(value, [{:key, key} | tail]) do
+  defp do_eval(value, [{:key, key} | tail], context) do
     value
     |> Indifferent.get(key)
-    |> apply_lazy(value)
-    |> do_eval(tail)
+    |> apply_lazy(value, context)
+    |> do_eval(tail, context)
   end
 
-  defp do_eval(value, [{:accessor, accessor} | tail]) do
+  defp do_eval(value, [{:accessor, accessor} | tail], context) do
     value
-    |> value_at(accessor)
-    |> apply_lazy(value)
-    |> do_eval(tail)
+    |> value_at(accessor, context)
+    |> apply_lazy(value, context)
+    |> do_eval(tail, context)
   end
 
-  defp value_at(value, index) when is_map(value), do: (Enum.at(value, index) || {nil, []}) |> elem(1)
-  defp value_at(value, index) when is_list(value), do: Enum.at(value, index)
-  defp value_at(_value, _index), do: []
+  defp value_at(value, argument, context) when is_tuple(argument) and is_map(value),
+    do: Indifferent.get(value, eval(argument, context))
+
+  defp value_at(value, argument, context) when is_tuple(argument) and is_list(value),
+    do: Enum.at(value, eval(argument, context))
+
+  defp value_at(_value, _index, _context), do: []
 
   # Apply a lazy function if needed
-  defp apply_lazy(fun, _parent) when is_function(fun, 0), do: fun.()
-  defp apply_lazy(fun, parent) when is_function(fun, 1), do: fun.(parent)
+  defp apply_lazy(fun, _parent, _context) when is_function(fun, 0), do: fun.()
+  defp apply_lazy(fun, parent, _context) when is_function(fun, 1), do: fun.(parent)
 
-  defp apply_lazy(value, _), do: value
+  defp apply_lazy(value, _, _context), do: value
 
   def assign(context, [argument], value), do: assign(context, argument, value)
 

--- a/lib/liquex/parser/field.ex
+++ b/lib/liquex/parser/field.ex
@@ -28,18 +28,24 @@ defmodule Liquex.Parser.Field do
     |> unwrap_and_tag(:accessor)
   end
 
+  @spec key_access(NimbleParsec.t()) :: NimbleParsec.t()
+  def key_access(combinator \\ empty()) do
+    combinator
+    |> ignore(string("."))
+    |> identifier()
+    |> unwrap_and_tag(:key)
+end
+
   @spec field(NimbleParsec.t()) :: NimbleParsec.t()
   def field(combinator \\ empty()) do
     combinator
     |> identifier()
     |> unwrap_and_tag(:key)
     |> optional(accessor())
-    |> repeat(
-      ignore(string("."))
-      |> identifier()
-      |> unwrap_and_tag(:key)
-      |> optional(accessor())
-    )
+    |> repeat(choice([
+      accessor(),
+      key_access()
+    ]))
     |> tag(:field)
   end
 end

--- a/lib/liquex/parser/field.ex
+++ b/lib/liquex/parser/field.ex
@@ -4,6 +4,7 @@ defmodule Liquex.Parser.Field do
   import NimbleParsec
 
   alias Liquex.Parser.Literal
+  alias Liquex.Parser.LiteralHelper
 
   @spec identifier(NimbleParsec.t()) :: NimbleParsec.t()
   def identifier(combinator \\ empty()) do
@@ -22,7 +23,7 @@ defmodule Liquex.Parser.Field do
     combinator
     |> ignore(string("["))
     |> ignore(Literal.whitespace())
-    |> integer(min: 1)
+    |> parsec({LiteralHelper, :argument})
     |> ignore(Literal.whitespace())
     |> ignore(string("]"))
     |> unwrap_and_tag(:accessor)
@@ -41,11 +42,11 @@ end
     combinator
     |> identifier()
     |> unwrap_and_tag(:key)
-    |> optional(accessor())
     |> repeat(choice([
       accessor(),
       key_access()
     ]))
     |> tag(:field)
   end
+
 end

--- a/lib/liquex/parser/literal.ex
+++ b/lib/liquex/parser/literal.ex
@@ -131,3 +131,9 @@ defmodule Liquex.Parser.Literal do
     ])
   end
 end
+defmodule Liquex.Parser.LiteralHelper do
+  import NimbleParsec
+  import Liquex.Parser.Literal
+
+  defcombinator(:argument, argument())
+end

--- a/lib/liquex/parser/object.ex
+++ b/lib/liquex/parser/object.ex
@@ -5,18 +5,21 @@ defmodule Liquex.Parser.Object do
 
   alias Liquex.Parser.Field
   alias Liquex.Parser.Literal
+  alias Liquex.Parser.LiteralHelper
 
   @spec arguments(NimbleParsec.t()) :: NimbleParsec.t()
   def arguments(combinator \\ empty()) do
     choice([
       combinator
-      |> Literal.argument()
+      # |> Literal.argument()
+      |> parsec({LiteralHelper, :argument})
       |> lookahead_not(string(":"))
       |> repeat(
         ignore(Literal.whitespace())
         |> ignore(string(","))
         |> ignore(Literal.whitespace())
-        |> concat(Literal.argument())
+        # |> concat(Literal.argument())
+        |> concat(parsec({LiteralHelper, :argument}))
         |> lookahead_not(string(":"))
       )
       |> optional(
@@ -45,7 +48,8 @@ defmodule Liquex.Parser.Object do
     |> concat(Field.identifier())
     |> ignore(string(":"))
     |> ignore(Literal.whitespace())
-    |> concat(Literal.argument())
+    # |> concat(Literal.argument())
+    |> concat(parsec({LiteralHelper, :argument}))
     |> tag(:keyword)
   end
 
@@ -73,7 +77,8 @@ defmodule Liquex.Parser.Object do
     |> ignore(string("{{"))
     |> ignore(optional(string("-")))
     |> ignore(Literal.whitespace())
-    |> Literal.argument()
+    # |> Literal.argument()
+    |> parsec({LiteralHelper, :argument})
     |> optional(tag(repeat(filter()), :filters))
     |> ignore(Literal.whitespace())
     |> ignore(choice([close_object_remove_whitespace(), string("}}")]))

--- a/lib/liquex/parser/object.ex
+++ b/lib/liquex/parser/object.ex
@@ -11,14 +11,12 @@ defmodule Liquex.Parser.Object do
   def arguments(combinator \\ empty()) do
     choice([
       combinator
-      # |> Literal.argument()
       |> parsec({LiteralHelper, :argument})
       |> lookahead_not(string(":"))
       |> repeat(
         ignore(Literal.whitespace())
         |> ignore(string(","))
         |> ignore(Literal.whitespace())
-        # |> concat(Literal.argument())
         |> concat(parsec({LiteralHelper, :argument}))
         |> lookahead_not(string(":"))
       )
@@ -48,7 +46,6 @@ defmodule Liquex.Parser.Object do
     |> concat(Field.identifier())
     |> ignore(string(":"))
     |> ignore(Literal.whitespace())
-    # |> concat(Literal.argument())
     |> concat(parsec({LiteralHelper, :argument}))
     |> tag(:keyword)
   end
@@ -77,7 +74,6 @@ defmodule Liquex.Parser.Object do
     |> ignore(string("{{"))
     |> ignore(optional(string("-")))
     |> ignore(Literal.whitespace())
-    # |> Literal.argument()
     |> parsec({LiteralHelper, :argument})
     |> optional(tag(repeat(filter()), :filters))
     |> ignore(Literal.whitespace())

--- a/test/liquex/argument_test.exs
+++ b/test/liquex/argument_test.exs
@@ -29,7 +29,7 @@ defmodule Liquex.ArgumentTest do
     test "evaluate with array field" do
       obj = Context.new(%{"field" => [%{}, %{"child" => 5}]})
 
-      assert 5 == Argument.eval([field: [key: "field", accessor: 1, key: "child"]], obj)
+      assert 5 == Argument.eval([field: [key: "field", accessor: {:literal, 1}, key: "child"]], obj)
     end
 
     test "evaluate with array.first" do
@@ -46,7 +46,7 @@ defmodule Liquex.ArgumentTest do
 
     test "evaluate with out of bounds array field" do
       obj = Context.new(%{"field" => [%{}, %{"child" => 5}]})
-      assert nil == Argument.eval([field: [key: "field", accessor: 5, key: "child"]], obj)
+      assert nil == Argument.eval([field: [key: "field", accessor: {:literal, 5}, key: "child"]], obj)
     end
 
     test "anonymous function field" do

--- a/test/liquex/parser/field_test.exs
+++ b/test/liquex/parser/field_test.exs
@@ -23,24 +23,24 @@ defmodule Liquex.Parser.FieldTest do
   test "with accessors" do
     assert_parse(
       "{{ field[1] }}",
-      object: [field: [key: "field", accessor: 1], filters: []]
+      object: [field: [key: "field", accessor: {:literal, 1}], filters: []]
     )
   end
 
   test "with accessor and child" do
     assert_parse(
       "{{ field[1].child }}",
-      object: [field: [key: "field", accessor: 1, key: "child"], filters: []]
+      object: [field: [key: "field", accessor: {:literal, 1}, key: "child"], filters: []]
     )
 
     assert_parse(
       "{{ field.child[0] }}",
-      object: [field: [key: "field", key: "child", accessor: 0], filters: []]
+      object: [field: [key: "field", key: "child", accessor: {:literal, 0}], filters: []]
     )
 
     assert_parse(
       "{{ field[1].child[0] }}",
-      object: [field: [key: "field", accessor: 1, key: "child", accessor: 0], filters: []]
+      object: [field: [key: "field", accessor: {:literal, 1}, key: "child", accessor: {:literal, 0}], filters: []]
     )
   end
 end

--- a/test/liquex/render/object_test.exs
+++ b/test/liquex/render/object_test.exs
@@ -25,6 +25,29 @@ defmodule Liquex.Render.ObjectTest do
       assert "1" == render("{{ b.c }}", context)
     end
 
+    test "list access to object fields" do
+      context =
+        Context.new(%{
+          "a" => ["b", ["c", "d"]]
+        })
+
+      assert "bcd" == render("{{ a }}", context)
+      assert "b" == render("{{ a[0] }}", context)
+      assert "cd" == render("{{ a[1] }}", context)
+      assert "c" == render("{{ a[1][0] }}", context)
+      assert "" == render("{{ a[2] }}", context)
+    end
+
+    test "wrong access to object and list fields" do
+      context =
+        Context.new(%{
+          "b" => %{"c" => 1}
+        })
+
+      assert "1" == render("{{ b[0] }}", context)
+      assert "" == render("{{ b[1] }}", context)
+    end
+
     test "removes tail whitespace" do
       assert "Hello" == render("{{ 'Hello' -}} ")
     end

--- a/test/liquex/render/object_test.exs
+++ b/test/liquex/render/object_test.exs
@@ -44,8 +44,7 @@ defmodule Liquex.Render.ObjectTest do
           "b" => %{"c" => 1}
         })
 
-      assert "1" == render("{{ b[0] }}", context)
-      assert "" == render("{{ b[1] }}", context)
+      assert "" == render("{{ b[0] }}", context)
     end
 
     test "removes tail whitespace" do
@@ -84,6 +83,41 @@ defmodule Liquex.Render.ObjectTest do
         })
 
       assert "Hello World" == render("{{ message.calculated_value }}", context)
+    end
+  end
+
+  describe "square brackets object access" do
+    test "simple field name" do
+      context =
+        Context.new(%{
+          "message" => %{"key" => "Hello World"}
+        })
+
+      assert "Hello World" == render("{{ message['key'] }}", context)
+      assert "Hello World" == render("{{ message[\"key\"] }}", context)
+    end
+
+    test "field name from context" do
+      context =
+        Context.new(%{
+          "keyvar" => "key",
+          "message" => %{
+            "key" => "Hello World"
+          }
+        })
+
+      assert "Hello World" == render("{{ message[keyvar] }}", context)
+    end
+
+    test "field name from variable" do
+      context =
+        Context.new(%{
+          "message" => %{
+            "map" => %{"key" => "Hello World"}
+          }
+        })
+
+      assert "Hello World" == render("{% assign mapvar = \"map\" %}{% assign keyvar = \"key\" %}{{ message[mapvar][keyvar] }}", context)
     end
   end
 


### PR DESCRIPTION
# Full dynamic Access to map fields

## Example of new accessor
```elixir
      context =
        Context.new(%{
          "message" => %{
            "mapkey" => "map",
            "map" => %{"key" => "Hello World"}
          }
        })

      assert "Hello World" ==
               render(
                 """
                 {% assign mapvar = \"mapkey\" %}
                 {% assign keyvar = \"key\" %}
                 {{ message[message[mapvar]][keyvar] }}
                 """,
                 context
               ) |> String.trim()

```