### PR TITLE
Support structs that implement the Access behavior 

### DIFF
--- a/lib/liquex/indifferent.ex
+++ b/lib/liquex/indifferent.ex
@@ -29,6 +29,18 @@ defmodule Liquex.Indifferent do
     end
   end
 
+  @spec put(map, any, any) :: map
+  @doc """
+  Puts a value in a key using indifferent access
+
+    ## Examples
+
+      iex> Liquex.Indifferent.put(%{"a" => "Hello"}, "a", "World")
+      %{"a" => "World"}
+
+      iex> Liquex.Indifferent.put(%{a: "Hello"}, "b", "World")
+      %{"b" => "World", :a => "Hello"}
+  """
   def put(map, key, value), do: Map.put(map, get_key!(map, key, key), value)
 
   @spec fetch(map, any) :: {:ok, term} | :error

--- a/lib/liquex/indifferent.ex
+++ b/lib/liquex/indifferent.ex
@@ -21,6 +21,9 @@ defmodule Liquex.Indifferent do
 
       iex> Liquex.Indifferent.get(%{a: "Hello"}, "b", "Goodbye")
       "Goodbye"
+
+      iex> Liquex.Indifferent.get(%StructWithAccess{key: "Hello"}, :key)
+      "Hello World"
   """
   def get(map, key, default \\ nil) do
     case fetch(map, key) do
@@ -63,7 +66,18 @@ defmodule Liquex.Indifferent do
 
       iex> Liquex.Indifferent.fetch(%{:a => "Hello", "a" => "Goodbye"}, "a")
       {:ok, "Goodbye"}
+
+      iex> Liquex.Indifferent.fetch(%StructWithAccess{key: "Hello"}, :key)
+      {:ok, "Hello World"}
   """
+  def fetch(data, key) when is_struct(data) do
+    if implements_access_fetch_behaviour?(data) do
+      Access.fetch(data, key)
+    else
+      Map.fetch(data, get_key!(data, key, key))
+    end
+  end
+
   def fetch(data, key), do: Map.fetch(data, get_key!(data, key, key))
 
   defp get_key(map, key) do
@@ -91,5 +105,9 @@ defmodule Liquex.Indifferent do
       {:ok, key} -> key
       _ -> default
     end
+  end
+
+  defp implements_access_fetch_behaviour?(struct) do
+    Kernel.function_exported?(struct.__struct__, :fetch, 2)
   end
 end

--- a/test/liquex/indifferent_test.exs
+++ b/test/liquex/indifferent_test.exs
@@ -3,5 +3,22 @@ defmodule Liquex.IndifferentTest do
 
   use ExUnit.Case, async: true
 
+  defmodule StructWithAccess do
+    @behaviour Access
+
+    defstruct [:key]
+
+    def fetch(container, :key) do
+      {:ok, container.key <> " World"}
+    end
+
+    def fetch(_container, _), do: :error
+
+    def pop(container, _key), do: {container.key, container}
+
+    def get_and_update(container, _key, func),
+      do: {container.key, %{container | key: func.(container.key)}}
+  end
+
   doctest Liquex.Indifferent
 end


### PR DESCRIPTION
This PR attempts to provide a solution for #25 

It enables the following:

```elixir
defmodule MyProductResolver do
  @behaviour Access

  defstruct []

  def fetch(_, key) do
    Product.get_by(handle: key) 
  end
end

iex> {:ok, template_ast} = Liquex.parse("Product title: {{ all_products['wayfarer-shades'].title }}")
iex> {content, _context} = Liquex.render(template_ast, %{all_products: % MyProductResolver{}})
iex> content |> to_string()

"Product title: Wayfarer Shades"
```