### PR TITLE
allow multiple values in a case when flow

### DIFF
--- a/lib/liquex/parser/tag/control_flow.ex
+++ b/lib/liquex/parser/tag/control_flow.ex
@@ -76,7 +76,15 @@ defmodule Liquex.Parser.Tag.ControlFlow do
       ignore(Tag.open_tag())
       |> ignore(string("when"))
       |> ignore(Literal.whitespace(empty(), 1))
-      |> tag(Literal.literal(), :expression)
+      |> tag(
+        Literal.literal()
+        |> repeat(
+          ignore(string(","))
+          |> ignore(Literal.whitespace(empty(), 1))
+          |> Literal.literal()
+        ),
+        :expression
+      )
       |> ignore(Tag.close_tag())
       |> tag(parsec(:document), :contents)
 

--- a/lib/liquex/render/control_flow.ex
+++ b/lib/liquex/render/control_flow.ex
@@ -39,8 +39,9 @@ defmodule Liquex.Render.ControlFlow do
 
   defp do_render([], context, _), do: {[], context}
 
-  defp do_render([{:when, [expression: expression, contents: contents]} | tail], context, match) do
-    if Argument.eval(expression, context) == match do
+  defp do_render([{:when, [expression: expressions, contents: contents]} | tail], context, match) do
+    expressions = Enum.map(expressions, &Argument.eval(&1, context))
+    if match in expressions do
       Liquex.render(contents, context)
     else
       do_render(tail, context, match)

--- a/test/integration/cases/case_when.hrx
+++ b/test/integration/cases/case_when.hrx
@@ -1,0 +1,12 @@
+<===> case_when.json
+{}
+
+<===> case_when.liquid
+
+{% assign foo = 'a' %}
+{% case foo %}
+{% when 'a', 'b' %}
+  bar
+{% else %}
+  buzz
+{% endcase %}

--- a/test/liquex/render/control_flow_test.exs
+++ b/test/liquex/render/control_flow_test.exs
@@ -142,6 +142,8 @@ defmodule Liquex.Render.ControlFlowTest do
             Hello, James!
           {% when "John" %}
             Hello, John!
+          {% when "Peter", "Paul" %}
+            Hello, Peter or Paul (cannot tell you apart).
           {% else %}
             Hello! Who are you?
         {% endcase %}
@@ -158,6 +160,16 @@ defmodule Liquex.Render.ControlFlowTest do
              |> elem(0)
              |> to_string()
              |> String.trim() == "Hello, John!"
+
+      assert Liquex.render(template, Context.new(%{"name" => "Peter"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello, Peter or Paul (cannot tell you apart)."
+
+      assert Liquex.render(template, Context.new(%{"name" => "Paul"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello, Peter or Paul (cannot tell you apart)."
 
       assert Liquex.render(template, Context.new(%{"name" => "Jim"}))
              |> elem(0)


### PR DESCRIPTION
like https://shopify.github.io/liquid/tags/control-flow/#:~:text=%7B%25%20when%20%22cookie%22%2C%20%22biscuit%22%20%25%7D

```
{% case %}
{% when 'a', 'b' %}
  a or b
{% endcase %}
```