### PR TITLE
Allow date filter to handle nil values

### DIFF
--- a/lib/liquex/filter.ex
+++ b/lib/liquex/filter.ex
@@ -245,6 +245,8 @@ defmodule Liquex.Filter do
     end
   end
 
+  def date(nil, _, _), do: nil
+
   @doc """
   Allows you to specify a fallback in case a value doesn’t exist. default will show its value
   if the left side is nil, false, or empty.

--- a/test/liquex/filter_test.exs
+++ b/test/liquex/filter_test.exs
@@ -9,4 +9,20 @@ defmodule Liquex.FilterTest do
   test "apply" do
     assert 5 == Filter.apply(-5, {:filter, ["abs", {:arguments, []}]}, %{})
   end
+
+  test "date" do
+    assert "2022" ==
+             Filter.apply(
+               ~D[2022-01-01],
+               {:filter, ["date", {:arguments, [{:literal, "%Y"}]}]},
+               %{}
+             )
+
+    assert nil ==
+             Filter.apply(
+               nil,
+               {:filter, ["date", {:arguments, [{:literal, "%Y"}]}]},
+               %{}
+             )
+  end
 end


### PR DESCRIPTION
In the current implementation, the date filter is unable to handle nil values and crashes w/ a `FunctionClauseError` when it encounters one.

I have a few other patches like this - not sure if you want to handle these cases this way, or want to rescue in `apply` push it onto the error context.