### PR TITLE
Feature/liquid tag

### DIFF
--- a/lib/liquex/filter.ex
+++ b/lib/liquex/filter.ex
@@ -559,14 +559,14 @@ defmodule Liquex.Filter do
   """
   @spec round(binary | number, binary | number, any) :: number
   def round(value, precision \\ 0, context),
-    do: do_round(to_number(value), to_number(precision, false), context)
+    do: do_round(to_number(value), to_number(precision, true), context)
 
   defp do_round(value, _, _) when is_integer(value), do: value
-  defp do_round(value, 0, _), do: Float.round(value) |> trunc()
+  defp do_round(value, precision, _) when precision <= 0, do: Float.round(value) |> trunc()
 
   defp do_round(value, precision, _) do
     # Special case negative and invalid precisions
-    precision = Enum.max([0, precision || 0])
+    precision = Enum.max([0, precision])
     Float.round(value, precision)
   end
 

--- a/lib/liquex/parser.ex
+++ b/lib/liquex/parser.ex
@@ -42,10 +42,11 @@ defmodule Liquex.Parser do
       Enum.each(tags, &Code.ensure_loaded!/1)
 
       liquid_tags_parser =
-        tags
-        |> Enum.filter(&function_exported?(&1, :parse_liquid_tag, 0))
-        |> Enum.map(&tag(&1.parse_liquid_tag(), {:tag, &1}))
-        |> choice()
+        choice(
+          tags
+          |> Enum.filter(&function_exported?(&1, :parse_liquid_tag, 0))
+          |> Enum.map(&tag(&1.parse_liquid_tag(), {:tag, &1}))
+        )
 
       # Special case for leading spaces before `{%-` and `{{-`
       leading_whitespace =

--- a/lib/liquex/parser.ex
+++ b/lib/liquex/parser.ex
@@ -42,11 +42,10 @@ defmodule Liquex.Parser do
       Enum.each(tags, &Code.ensure_loaded!/1)
 
       liquid_tags_parser =
-        choice(
-          tags
-          |> Enum.filter(&function_exported?(&1, :parse_liquid_tag, 0))
-          |> Enum.map(&tag(&1.parse_liquid_tag(), {:tag, &1}))
-        )
+        tags
+        |> Enum.filter(&function_exported?(&1, :parse_liquid_tag, 0))
+        |> Enum.map(&tag(&1.parse_liquid_tag(), {:tag, &1}))
+        |> choice()
 
       # Special case for leading spaces before `{%-` and `{{-`
       leading_whitespace =

--- a/lib/liquex/parser.ex
+++ b/lib/liquex/parser.ex
@@ -11,28 +11,41 @@ defmodule Liquex.Parser do
     quote location: :keep do
       import NimbleParsec
 
-      custom_tags = Enum.map(unquote(tags), &tag(&1.parse(), {:tag, &1}))
+      custom_tags = unquote(tags)
 
       tags =
-        [
-          Liquex.Tag.AssignTag,
-          Liquex.Tag.BreakTag,
-          Liquex.Tag.CaptureTag,
-          Liquex.Tag.CaseTag,
-          Liquex.Tag.CommentTag,
-          Liquex.Tag.ContinueTag,
-          Liquex.Tag.CycleTag,
-          Liquex.Tag.EchoTag,
-          Liquex.Tag.ForTag,
-          Liquex.Tag.IfTag,
-          Liquex.Tag.IncrementTag,
-          Liquex.Tag.ObjectTag,
-          Liquex.Tag.RawTag,
-          Liquex.Tag.RenderTag,
-          Liquex.Tag.TablerowTag,
-          Liquex.Tag.UnlessTag
-        ]
-        |> Enum.map(&tag(&1.parse(), {:tag, &1}))
+        custom_tags ++
+          [
+            Liquex.Tag.AssignTag,
+            Liquex.Tag.BreakTag,
+            Liquex.Tag.CaptureTag,
+            Liquex.Tag.CaseTag,
+            Liquex.Tag.CommentTag,
+            Liquex.Tag.ContinueTag,
+            Liquex.Tag.CycleTag,
+            Liquex.Tag.EchoTag,
+            Liquex.Tag.ForTag,
+            Liquex.Tag.IfTag,
+            Liquex.Tag.IncrementTag,
+            Liquex.Tag.LiquidTag,
+            Liquex.Tag.ObjectTag,
+            Liquex.Tag.RawTag,
+            Liquex.Tag.RenderTag,
+            Liquex.Tag.TablerowTag,
+            Liquex.Tag.UnlessTag
+          ]
+
+      tags_parser = Enum.map(tags, &tag(&1.parse(), {:tag, &1}))
+
+      # Ensure the tags are loaded into scope, otherwise function_exported? will
+      # return false
+      Enum.each(tags, &Code.ensure_loaded!/1)
+
+      liquid_tags_parser =
+        tags
+        |> Enum.filter(&function_exported?(&1, :parse_liquid_tag, 0))
+        |> Enum.map(&tag(&1.parse_liquid_tag(), {:tag, &1}))
+        |> choice()
 
       # Special case for leading spaces before `{%-` and `{{-`
       leading_whitespace =
@@ -44,8 +57,7 @@ defmodule Liquex.Parser do
 
       base =
         choice(
-          custom_tags ++
-            tags ++
+          tags_parser ++
             [
               # credo:disable-for-lines:2
               Liquex.Parser.Literal.text(),
@@ -54,6 +66,8 @@ defmodule Liquex.Parser do
         )
 
       defcombinatorp(:document, repeat(base))
+      defcombinatorp(:liquid_tag_contents, repeat(liquid_tags_parser))
+
       defparsec(:parse, parsec(:document) |> eos())
     end
   end

--- a/lib/liquex/parser.ex
+++ b/lib/liquex/parser.ex
@@ -22,6 +22,7 @@ defmodule Liquex.Parser do
           Liquex.Tag.CommentTag,
           Liquex.Tag.ContinueTag,
           Liquex.Tag.CycleTag,
+          Liquex.Tag.EchoTag,
           Liquex.Tag.ForTag,
           Liquex.Tag.IfTag,
           Liquex.Tag.IncrementTag,

--- a/lib/liquex/parser/literal.ex
+++ b/lib/liquex/parser/literal.ex
@@ -22,6 +22,20 @@ defmodule Liquex.Parser.Literal do
   end
 
   @doc """
+  Parses not line breaking white space, given a minimum.
+
+  ## Examples
+
+      * "  "
+      * "\t"
+  """
+  @spec non_breaking_whitespace(NimbleParsec.t(), non_neg_integer()) :: NimbleParsec.t()
+  def non_breaking_whitespace(combinator \\ empty(), min \\ 0) do
+    combinator
+    |> utf8_string([?\s, ?\t], min: min)
+  end
+
+  @doc """
   Parses a range
 
   ## Examples

--- a/lib/liquex/parser/tag.ex
+++ b/lib/liquex/parser/tag.ex
@@ -39,6 +39,17 @@ defmodule Liquex.Parser.Tag do
     |> choice([close_tag_remove_whitespace(), string("%}")])
   end
 
+  def end_liquid_line(combinator \\ empty()) do
+    combinator
+    |> utf8_string([?\s, ?\t], min: 0)
+    |> choice([
+      empty()
+      |> utf8_string([?\r, ?\n], 1)
+      |> Literal.whitespace(0),
+      lookahead(string("%}"))
+    ])
+  end
+
   @doc """
   Parse basic tag with no arguments
 

--- a/lib/liquex/render.ex
+++ b/lib/liquex/render.ex
@@ -5,10 +5,12 @@ defmodule Liquex.Render do
 
   @callback render({atom, any}, Context.t()) :: {iodata, Context.t()} | iodata | false
 
-  @spec render(iodata(), Liquex.document_t(), Context.t()) ::
+  @type result_t ::
           {iodata(), Context.t()}
           | {:break, iodata(), Context.t()}
           | {:continue, iodata(), Context.t()}
+
+  @spec render(iodata(), Liquex.document_t(), Context.t()) :: result_t
 
   @doc """
   Renders a Liquid AST `document` into an `iodata`

--- a/lib/liquex/tag.ex
+++ b/lib/liquex/tag.ex
@@ -64,8 +64,5 @@ defmodule Liquex.Tag do
   @doc """
   Render the tag built by the parser defined in `parse/0`
   """
-  @callback render(list, Liquex.Context.t()) ::
-              {iodata, Liquex.Context.t()}
-              | {:break, iodata, Liquex.Context.t()}
-              | {:continue, iodata, Liquex.Context.t()}
+  @callback render(list, Liquex.Context.t()) :: Liquex.Render.result_t()
 end

--- a/lib/liquex/tag.ex
+++ b/lib/liquex/tag.ex
@@ -51,6 +51,17 @@ defmodule Liquex.Tag do
   @callback parse() :: NimbleParsec.t()
 
   @doc """
+  Returns a `NimbleParsec` expression to parse a tag within a liquid expression
+  tag.
+
+  ### Example
+
+      {% liquid echo "Hello World!" %}
+  """
+  @callback parse_liquid_tag() :: NimbleParsec.t()
+  @optional_callbacks parse_liquid_tag: 0
+
+  @doc """
   Render the tag built by the parser defined in `parse/0`
   """
   @callback render(list, Liquex.Context.t()) ::

--- a/lib/liquex/tag/assign_tag.ex
+++ b/lib/liquex/tag/assign_tag.ex
@@ -39,11 +39,22 @@ defmodule Liquex.Tag.AssignTag do
   import NimbleParsec
 
   def parse do
+    ignore(Tag.open_tag())
+    |> assign_contents()
+    |> ignore(Tag.close_tag())
+  end
+
+  def parse_liquid_tag do
+    assign_contents()
+    |> ignore(Tag.end_liquid_line())
+  end
+
+  def assign_contents(combinator \\ empty()) do
     literal_and_filters =
       Argument.argument()
       |> optional(tag(repeat(Object.filter()), :filters))
 
-    ignore(Tag.open_tag())
+    combinator
     |> ignore(string("assign"))
     |> ignore(Literal.whitespace())
     |> unwrap_and_tag(Field.identifier(), :left)
@@ -51,7 +62,6 @@ defmodule Liquex.Tag.AssignTag do
     |> ignore(string("="))
     |> ignore(Literal.whitespace())
     |> tag(literal_and_filters, :right)
-    |> ignore(Tag.close_tag())
   end
 
   def render([left: left, right: [right, filters: filters]], %Context{} = context)

--- a/lib/liquex/tag/break_tag.ex
+++ b/lib/liquex/tag/break_tag.ex
@@ -29,6 +29,11 @@ defmodule Liquex.Tag.BreakTag do
   end
 
   @impl true
+  def parse_liquid_tag do
+    ignore(Tag.liquid_tag_directive("break"))
+  end
+
+  @impl true
   def render(_, context) do
     {:break, [], context}
   end

--- a/lib/liquex/tag/comment_tag.ex
+++ b/lib/liquex/tag/comment_tag.ex
@@ -35,5 +35,10 @@ defmodule Liquex.Tag.CommentTag do
   end
 
   @impl true
+  def parse_liquid_tag do
+    string("USDFADSJFKAJDFJKASDF")
+  end
+
+  @impl true
   def render(_contents, context), do: {[], context}
 end

--- a/lib/liquex/tag/continue_tag.ex
+++ b/lib/liquex/tag/continue_tag.ex
@@ -25,9 +25,10 @@ defmodule Liquex.Tag.ContinueTag do
   import NimbleParsec
 
   @impl true
-  def parse do
-    ignore(Tag.tag_directive("continue"))
-  end
+  def parse, do: ignore(Tag.tag_directive("continue"))
+
+  @impl true
+  def parse_liquid_tag, do: ignore(Tag.liquid_tag_directive("continue"))
 
   @impl true
   def render(_, context), do: {:continue, [], context}

--- a/lib/liquex/tag/cycle_tag.ex
+++ b/lib/liquex/tag/cycle_tag.ex
@@ -56,17 +56,27 @@ defmodule Liquex.Tag.CycleTag do
   import NimbleParsec
 
   def parse do
+    ignore(Tag.open_tag())
+    |> do_parse_cycle()
+    |> ignore(Tag.close_tag())
+  end
+
+  def parse_liquid_tag do
+    do_parse_cycle()
+    |> ignore(Tag.end_liquid_line())
+  end
+
+  def do_parse_cycle(combinator \\ empty()) do
     cycle_group =
       Literal.literal()
       |> ignore(string(":"))
-      |> ignore(Literal.whitespace())
+      |> ignore(Literal.non_breaking_whitespace())
 
-    ignore(Tag.open_tag())
+    combinator
     |> ignore(string("cycle"))
-    |> ignore(Literal.whitespace(empty(), 1))
+    |> ignore(Literal.non_breaking_whitespace(empty(), 1))
     |> optional(unwrap_and_tag(cycle_group, :group))
     |> tag(argument_sequence(), :sequence)
-    |> ignore(Tag.close_tag())
   end
 
   defp argument_sequence(combinator \\ empty()) do
@@ -74,7 +84,7 @@ defmodule Liquex.Tag.CycleTag do
     |> Argument.argument()
     |> repeat(
       ignore(string(","))
-      |> ignore(Literal.whitespace())
+      |> ignore(Literal.non_breaking_whitespace())
       |> Argument.argument()
     )
   end

--- a/lib/liquex/tag/echo_tag.ex
+++ b/lib/liquex/tag/echo_tag.ex
@@ -27,6 +27,7 @@ defmodule Liquex.Tag.EchoTag do
 
   alias Liquex.Render
 
+  @impl true
   def parse do
     ignore(Tag.open_tag())
     |> ignore(string("echo"))
@@ -37,6 +38,20 @@ defmodule Liquex.Tag.EchoTag do
     |> ignore(Tag.close_tag())
   end
 
+  @impl true
+  def parse_liquid_tag do
+    ignore(string("echo"))
+    |> echo_contents()
+  end
+
+  defp echo_contents(combinator) do
+    combinator
+    |> ignore(Literal.whitespace(empty(), 1))
+    |> Argument.argument()
+    |> optional(ObjectTag.filters())
+  end
+
+  @impl true
   def render([argument, filters: filters], %Context{} = context) do
     {result, context} =
       argument

--- a/lib/liquex/tag/echo_tag.ex
+++ b/lib/liquex/tag/echo_tag.ex
@@ -30,22 +30,20 @@ defmodule Liquex.Tag.EchoTag do
   @impl true
   def parse do
     ignore(Tag.open_tag())
-    |> ignore(string("echo"))
-    |> ignore(Literal.whitespace(empty(), 1))
-    |> Argument.argument()
-    |> optional(ObjectTag.filters())
+    |> echo_contents()
     |> ignore(Literal.whitespace())
     |> ignore(Tag.close_tag())
   end
 
   @impl true
   def parse_liquid_tag do
-    ignore(string("echo"))
-    |> echo_contents()
+    echo_contents()
+    |> ignore(Tag.end_liquid_line())
   end
 
-  defp echo_contents(combinator) do
+  defp echo_contents(combinator \\ empty()) do
     combinator
+    |> ignore(string("echo"))
     |> ignore(Literal.whitespace(empty(), 1))
     |> Argument.argument()
     |> optional(ObjectTag.filters())

--- a/lib/liquex/tag/echo_tag.ex
+++ b/lib/liquex/tag/echo_tag.ex
@@ -1,18 +1,18 @@
 defmodule Liquex.Tag.EchoTag do
   @moduledoc """
-  Objects contain the content that Liquid displays on a page. Objects and
-  variables are displayed when enclosed in double curly braces: {{ and }}.
+  Outputs an expression in the rendered HTML. This is identical to wrapping an
+  expression in {{ and }}, but works inside liquid tags and supports filters.
 
   ### Input
 
-      {{ page.title }}
+      {% liquid
+      for product in collection.products
+        echo product.title | capitalize
+      endfor %}
 
   ### Output
 
-      Introduction
-
-  In this case, Liquid is rendering the content of the title property of the
-  page object, which contains the text Introduction.
+      Hat Shirt Pants
   """
 
   @behaviour Liquex.Tag

--- a/lib/liquex/tag/echo_tag.ex
+++ b/lib/liquex/tag/echo_tag.ex
@@ -20,10 +20,10 @@ defmodule Liquex.Tag.EchoTag do
 
   alias Liquex.Context
 
-  alias Liquex.Parser.Tag
   alias Liquex.Parser.Argument
-  alias Liquex.Tag.ObjectTag
   alias Liquex.Parser.Literal
+  alias Liquex.Parser.Tag
+  alias Liquex.Tag.ObjectTag
 
   alias Liquex.Render
 

--- a/lib/liquex/tag/echo_tag.ex
+++ b/lib/liquex/tag/echo_tag.ex
@@ -1,0 +1,49 @@
+defmodule Liquex.Tag.EchoTag do
+  @moduledoc """
+  Objects contain the content that Liquid displays on a page. Objects and
+  variables are displayed when enclosed in double curly braces: {{ and }}.
+
+  ### Input
+
+      {{ page.title }}
+
+  ### Output
+
+      Introduction
+
+  In this case, Liquid is rendering the content of the title property of the
+  page object, which contains the text Introduction.
+  """
+
+  @behaviour Liquex.Tag
+  import NimbleParsec
+
+  alias Liquex.Context
+
+  alias Liquex.Parser.Tag
+  alias Liquex.Parser.Argument
+  alias Liquex.Tag.ObjectTag
+  alias Liquex.Parser.Literal
+
+  alias Liquex.Render
+
+  def parse do
+    ignore(Tag.open_tag())
+    |> ignore(string("echo"))
+    |> ignore(Literal.whitespace(empty(), 1))
+    |> Argument.argument()
+    |> optional(ObjectTag.filters())
+    |> ignore(Literal.whitespace())
+    |> ignore(Tag.close_tag())
+  end
+
+  def render([argument, filters: filters], %Context{} = context) do
+    {result, context} =
+      argument
+      |> List.wrap()
+      |> Liquex.Argument.eval(context)
+      |> Render.apply_filters(filters, context)
+
+    {to_string(result), context}
+  end
+end

--- a/lib/liquex/tag/increment_tag.ex
+++ b/lib/liquex/tag/increment_tag.ex
@@ -85,6 +85,19 @@ defmodule Liquex.Tag.IncrementTag do
     |> post_traverse({__MODULE__, :reverse_tags, []})
   end
 
+  def parse_liquid_tag do
+    # Replace as {default, increment}
+    increment = replace(string("increment"), {0, 1})
+    decrement = replace(string("decrement"), {-1, -1})
+
+    choice([increment, decrement])
+    |> unwrap_and_tag(:by)
+    |> ignore(Literal.non_breaking_whitespace(empty(), 0))
+    |> optional(unwrap_and_tag(Field.identifier(), :identifier))
+    |> ignore(Tag.end_liquid_line())
+    |> post_traverse({__MODULE__, :reverse_tags, []})
+  end
+
   def reverse_tags(_rest, args, context, _line, _offset),
     do: {args |> Enum.reverse(), context}
 

--- a/lib/liquex/tag/liquid_tag.ex
+++ b/lib/liquex/tag/liquid_tag.ex
@@ -1,6 +1,25 @@
 defmodule Liquex.Tag.LiquidTag do
   @moduledoc """
 
+  ## liquid
+
+  Encloses multiple tags within one set of delimiters, to allow writing Liquid
+  logic more concisely.
+
+      {% liquid
+      case section.blocks.size
+      when 1
+        assign column_size = ''
+      when 2
+        assign column_size = 'one-half'
+      when 3
+        assign column_size = 'one-third'
+      else
+        assign column_size = 'one-quarter'
+      endcase %}
+
+  Because any tag blocks opened within a liquid tag must also be closed within
+  the same tag, use echo to output data.
   """
 
   @behaviour Liquex.Tag
@@ -8,8 +27,8 @@ defmodule Liquex.Tag.LiquidTag do
 
   alias Liquex.Context
 
-  alias Liquex.Parser.Tag
   alias Liquex.Parser.Literal
+  alias Liquex.Parser.Tag
 
   alias Liquex.Render
 

--- a/lib/liquex/tag/liquid_tag.ex
+++ b/lib/liquex/tag/liquid_tag.ex
@@ -14,6 +14,7 @@ defmodule Liquex.Tag.LiquidTag do
   alias Liquex.Render
 
   @impl true
+  @spec parse :: NimbleParsec.t()
   def parse do
     Tag.open_tag()
     |> string("liquid")
@@ -25,7 +26,6 @@ defmodule Liquex.Tag.LiquidTag do
   end
 
   @impl true
-  def render([contents: contents], %Context{} = context) do
-    Render.render(contents, context)
-  end
+  @spec render(list, Liquex.Context.t()) :: Render.result_t()
+  def render([contents: contents], %Context{} = context), do: Render.render(contents, context)
 end

--- a/lib/liquex/tag/liquid_tag.ex
+++ b/lib/liquex/tag/liquid_tag.ex
@@ -40,7 +40,7 @@ defmodule Liquex.Tag.LiquidTag do
     |> Literal.whitespace(1)
     |> ignore()
     |> tag(parsec(:liquid_tag_contents), :contents)
-    |> ignore(Literal.whitespace(empty(), 0))
+    |> ignore(Literal.whitespace())
     |> ignore(Tag.close_tag())
   end
 

--- a/lib/liquex/tag/liquid_tag.ex
+++ b/lib/liquex/tag/liquid_tag.ex
@@ -1,0 +1,31 @@
+defmodule Liquex.Tag.LiquidTag do
+  @moduledoc """
+
+  """
+
+  @behaviour Liquex.Tag
+  import NimbleParsec
+
+  alias Liquex.Context
+
+  alias Liquex.Parser.Tag
+  alias Liquex.Parser.Literal
+
+  alias Liquex.Render
+
+  @impl true
+  def parse do
+    Tag.open_tag()
+    |> string("liquid")
+    |> Literal.whitespace(1)
+    |> ignore()
+    |> tag(parsec(:liquid_tag_contents), :contents)
+    |> ignore(Literal.whitespace(empty(), 0))
+    |> ignore(Tag.close_tag())
+  end
+
+  @impl true
+  def render([contents: contents], %Context{} = context) do
+    Render.render(contents, context)
+  end
+end

--- a/lib/liquex/tag/object_tag.ex
+++ b/lib/liquex/tag/object_tag.ex
@@ -31,9 +31,15 @@ defmodule Liquex.Tag.ObjectTag do
     |> ignore(optional(string("-")))
     |> ignore(Literal.whitespace())
     |> Argument.argument()
-    |> optional(tag(repeat(filter()), :filters))
+    |> optional(filters())
     |> ignore(Literal.whitespace())
     |> ignore(choice([close_object_remove_whitespace(), string("}}")]))
+  end
+
+  @spec filters(NimbleParsec.t()) :: NimbleParsec.t()
+  def filters(combinator \\ empty()) do
+    combinator
+    |> tag(repeat(filter()), :filters)
   end
 
   defp arguments do

--- a/lib/liquex/tag/render_tag.ex
+++ b/lib/liquex/tag/render_tag.ex
@@ -68,15 +68,24 @@ defmodule Liquex.Tag.RenderTag do
 
   @spec parse :: NimbleParsec.t()
   def parse do
-    ignore(
-      Tag.open_tag()
-      |> string("render")
-      |> Literal.whitespace()
-    )
+    Tag.open_tag()
+    |> do_parse()
+    |> ignore(Tag.close_tag())
+  end
+
+  def parse_liquid_tag do
+    do_parse()
+    |> ignore(Tag.end_liquid_line())
+  end
+
+  defp do_parse(combinator \\ empty()) do
+    combinator
+    |> string("render")
+    |> Literal.whitespace(1)
+    |> ignore()
     |> Literal.literal()
     |> unwrap_and_tag(:template)
     |> optional(choice([keyword_list(), with_clause(), for_loop()]))
-    |> ignore(Tag.close_tag())
   end
 
   defp keyword_list do

--- a/lib/liquex/tag/unless_tag.ex
+++ b/lib/liquex/tag/unless_tag.ex
@@ -29,6 +29,7 @@ defmodule Liquex.Tag.UnlessTag do
 
   alias Liquex.Tag.IfTag
 
+  @impl true
   def parse do
     Tag.expression_tag("unless")
     |> tag(parsec(:document), :contents)
@@ -37,6 +38,24 @@ defmodule Liquex.Tag.UnlessTag do
     |> ignore(Tag.tag_directive("endunless"))
   end
 
+  @impl true
+  def parse_liquid_tag do
+    Tag.liquid_tag_expression("unless")
+    |> tag(parsec(:liquid_tag_contents), :contents)
+    |> repeat(
+      Tag.liquid_tag_expression("elsif")
+      |> tag(parsec(:liquid_tag_contents), :contents)
+      |> tag(:elsif)
+    )
+    |> optional(
+      ignore(Tag.liquid_tag_directive("else"))
+      |> tag(parsec(:liquid_tag_contents), :contents)
+      |> tag(:else)
+    )
+    |> ignore(Tag.liquid_tag_directive("endunless"))
+  end
+
+  @impl true
   def render([{:expression, expression}, {:contents, contents} | tail], context) do
     if Expression.eval(expression, context) do
       IfTag.render(tail, context)

--- a/test/integration/cases/increment.hrx
+++ b/test/integration/cases/increment.hrx
@@ -14,3 +14,11 @@
 {% increment x %}
 {% increment x %}
 {{ x }}
+
+
+{% liquid
+  increment y
+  increment y
+  increment y
+  increment y
+%}

--- a/test/integration/cases/liquid_tag.hrx
+++ b/test/integration/cases/liquid_tag.hrx
@@ -1,0 +1,23 @@
+<===> liquid_tag.json
+{
+  "product": {
+    "type": "Health"
+  }
+}
+
+<===> liquid_tag.liquid
+{% liquid
+  assign product_type = product.type | downcase
+  assign message = '' | downcase
+
+  case product_type
+    when 'health'
+      assign message = 'This is a health potion!'
+    when 'love'
+      assign message = 'This is a love potion!'
+    else
+      assign message = 'This is a potion!'
+  endcase
+
+  echo message
+%}

--- a/test/integration/cases/liquid_tag.hrx
+++ b/test/integration/cases/liquid_tag.hrx
@@ -6,6 +6,9 @@
 }
 
 <===> liquid_tag.liquid
+
+case and echo tags
+
 {% liquid
   assign product_type = product.type | downcase
   assign message = '' | downcase
@@ -20,4 +23,13 @@
   endcase
 
   echo message
+%}
+
+if/else tags
+
+{% liquid assign name = "John"
+
+  if name == "Jane"
+    echo "Hello Jane"
+  endif
 %}

--- a/test/liquex/tag/assign_tag_test.exs
+++ b/test/liquex/tag/assign_tag_test.exs
@@ -91,4 +91,58 @@ defmodule Liquex.Tag.AssignTagTest do
              |> String.trim() == "5"
     end
   end
+
+  describe "render with liquid tag" do
+    test "assign simple value" do
+      context = Context.new(%{})
+
+      {:ok, template} =
+        """
+        {% liquid assign a = "Hello World!" %}
+        {{ a }}
+        """
+        |> String.trim()
+        |> Liquex.parse()
+
+      assert Liquex.render(template, context)
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello World!"
+    end
+
+    test "assign another field" do
+      context = Context.new(%{"a" => %{"b" => "Hello World!"}})
+
+      {:ok, template} =
+        """
+        {% liquid assign c = a.b %}
+        {{ c }}
+        """
+        |> String.trim()
+        |> Liquex.parse()
+
+      assert Liquex.render(template, context)
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello World!"
+    end
+
+    test "assign another field with filter" do
+      context = Context.new(%{"a" => %{"b" => 10}})
+
+      {:ok, template} =
+        """
+        {% liquid assign b = a.b
+         assign c = a.b | divided_by: 2 %}
+        {{ c }}
+        """
+        |> String.trim()
+        |> Liquex.parse()
+
+      assert Liquex.render(template, context)
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "5"
+    end
+  end
 end

--- a/test/liquex/tag/break_tag_test.exs
+++ b/test/liquex/tag/break_tag_test.exs
@@ -48,6 +48,18 @@ defmodule Liquex.Tag.BreakTagTest do
       assert Liquex.render(template, %{})
              |> elem(0)
              |> to_string() == "123"
+
+      assert render("""
+               {% liquid
+                 for i in (1..5)
+                   echo i
+
+                   if i > 2
+                     break
+                   endif
+                 endfor
+               %}
+             """) == "123"
     end
   end
 end

--- a/test/liquex/tag/case_tag_test.exs
+++ b/test/liquex/tag/case_tag_test.exs
@@ -110,4 +110,49 @@ defmodule Liquex.Tag.CaseTagTest do
              |> String.trim() == "Hello! Who are you?"
     end
   end
+
+  describe "render with liquid tag" do
+    test "simple case" do
+      {:ok, template} =
+        """
+        {% liquid case name
+          when "James"
+            echo "Hello, James!"
+          when "John"
+            echo "Hello, John!"
+          when "Peter", "Paul"
+            echo "Hello, Peter or Paul (cannot tell you apart)."
+          else
+            echo "Hello! Who are you?"
+        endcase %}
+        """
+        |> String.trim()
+        |> Liquex.parse()
+
+      assert Liquex.render(template, Context.new(%{"name" => "James"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello, James!"
+
+      assert Liquex.render(template, Context.new(%{"name" => "John"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello, John!"
+
+      assert Liquex.render(template, Context.new(%{"name" => "Peter"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello, Peter or Paul (cannot tell you apart)."
+
+      assert Liquex.render(template, Context.new(%{"name" => "Paul"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello, Peter or Paul (cannot tell you apart)."
+
+      assert Liquex.render(template, Context.new(%{"name" => "Jim"}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "Hello! Who are you?"
+    end
+  end
 end

--- a/test/liquex/tag/continue_tag_test.exs
+++ b/test/liquex/tag/continue_tag_test.exs
@@ -37,6 +37,19 @@ defmodule Liquex.Tag.ContinueTagTest do
       assert Liquex.render(template, %{"x" => 1..40})
              |> elem(0)
              |> to_string() == "HelloHello"
+
+      assert render(
+               """
+                 {% liquid for i in x
+                   if i > 2
+                     continue
+                   endif
+
+                   echo "Hello"
+                 endfor %}
+               """,
+               Liquex.Context.new(%{"x" => 1..40})
+             ) == "HelloHello"
     end
   end
 end

--- a/test/liquex/tag/cycle_tag_test.exs
+++ b/test/liquex/tag/cycle_tag_test.exs
@@ -54,6 +54,15 @@ defmodule Liquex.Tag.CycleTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(one two three one)
+
+      assert render("""
+             {% liquid
+             cycle "one", "two", "three"
+             cycle "one", "two", "three"
+             cycle "one", "two", "three"
+             cycle "one", "two", "three"
+             %}
+             """) == "onetwothreeone"
     end
 
     test "named cycle" do
@@ -73,6 +82,15 @@ defmodule Liquex.Tag.CycleTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(one one two two)
+
+      assert render("""
+             {% liquid
+               cycle "first": "one", "two", "three"
+               cycle "second": "one", "two", "three"
+               cycle "second": "one", "two", "three"
+               cycle "first": "one", "two", "three"
+             %}
+             """) == "oneonetwotwo"
     end
   end
 

--- a/test/liquex/tag/echo_tag_test.exs
+++ b/test/liquex/tag/echo_tag_test.exs
@@ -3,7 +3,6 @@ defmodule Liquex.Tag.EchoTagTest do
   import Liquex.TestHelpers
 
   alias Liquex.Context
-  alias Liquex.Parser.Base
 
   describe "parse" do
     test "handles simple object" do
@@ -109,6 +108,7 @@ defmodule Liquex.Tag.EchoTagTest do
   describe "render" do
     test "simple objects" do
       assert "5" == render("{% echo 5 %}")
+      assert "5" == render("{% liquid echo 5 %}")
       assert "Hello" == render("{% echo 'Hello' %}")
       assert "true" == render("{% echo true %}")
       assert "" == render("{% echo nil %}")
@@ -223,13 +223,5 @@ defmodule Liquex.Tag.EchoTagTest do
                  context
                )
     end
-  end
-
-  def render(doc, context \\ %Context{}) do
-    {:ok, parsed_doc, _, _, _, _} = Base.parse(doc)
-
-    {result, _} = Liquex.render(parsed_doc, context)
-
-    result |> to_string()
   end
 end

--- a/test/liquex/tag/echo_tag_test.exs
+++ b/test/liquex/tag/echo_tag_test.exs
@@ -1,0 +1,235 @@
+defmodule Liquex.Tag.EchoTagTest do
+  use ExUnit.Case, async: true
+  import Liquex.TestHelpers
+
+  alias Liquex.Context
+  alias Liquex.Parser.Base
+
+  describe "parse" do
+    test "handles simple object" do
+      assert_parse(
+        "{% echo true %}",
+        [
+          {{:tag, Liquex.Tag.EchoTag}, [literal: true, filters: []]}
+        ]
+      )
+    end
+
+    test "handles simple filter" do
+      assert_parse(
+        "{% echo true | not %}",
+        [
+          {{:tag, Liquex.Tag.EchoTag},
+           [literal: true, filters: [filter: ["not", {:arguments, []}]]]}
+        ]
+      )
+    end
+
+    test "parses filter with single argument" do
+      assert_parse(
+        "{% echo 123.45 | money: 'USD' %}",
+        [
+          {{:tag, Liquex.Tag.EchoTag},
+           [literal: 123.45, filters: [filter: ["money", {:arguments, [literal: "USD"]}]]]}
+        ]
+      )
+    end
+
+    test "parses filter with multiple arguments" do
+      assert_parse(
+        "{% echo 123.45 | money: 'USD', format %}",
+        [
+          {
+            {:tag, Liquex.Tag.EchoTag},
+            [
+              literal: 123.45,
+              filters: [filter: ["money", {:arguments, [literal: "USD", field: [key: "format"]]}]]
+            ]
+          }
+        ]
+      )
+    end
+
+    test "parses filter with key/value arguments" do
+      assert_parse(
+        "{% echo product | img_url: '400x400', crop: 'bottom' %}",
+        [
+          {
+            {:tag, Liquex.Tag.EchoTag},
+            [
+              field: [key: "product"],
+              filters: [
+                filter: [
+                  "img_url",
+                  {:arguments, [literal: "400x400", keyword: ["crop", {:literal, "bottom"}]]}
+                ]
+              ]
+            ]
+          }
+        ]
+      )
+    end
+
+    test "parses filter with key/value arguments as first argument" do
+      assert_parse(
+        "{% echo product | img_url: crop: 'bottom' %}",
+        [
+          {
+            {:tag, Liquex.Tag.EchoTag},
+            [
+              field: [key: "product"],
+              filters: [
+                filter: ["img_url", {:arguments, [keyword: ["crop", {:literal, "bottom"}]]}]
+              ]
+            ]
+          }
+        ]
+      )
+    end
+
+    test "parses multiple filters" do
+      assert_parse(
+        "{% echo 'adam!' | capitalize | prepend: 'Hello ' %}",
+        [
+          {
+            {:tag, Liquex.Tag.EchoTag},
+            [
+              literal: "adam!",
+              filters: [
+                filter: ["capitalize", {:arguments, []}],
+                filter: ["prepend", {:arguments, [literal: "Hello "]}]
+              ]
+            ]
+          }
+        ]
+      )
+    end
+  end
+
+  describe "render" do
+    test "simple objects" do
+      assert "5" == render("{% echo 5 %}")
+      assert "Hello" == render("{% echo 'Hello' %}")
+      assert "true" == render("{% echo true %}")
+      assert "" == render("{% echo nil %}")
+    end
+
+    test "simple fields" do
+      context =
+        Context.new(%{
+          "a" => "hello",
+          "b" => %{"c" => 1}
+        })
+
+      assert "hello" == render("{% echo a %}", context)
+      assert "1" == render("{% echo b.c %}", context)
+    end
+
+    test "list access to object fields" do
+      context =
+        Context.new(%{
+          "a" => ["b", ["c", "d"]]
+        })
+
+      assert "bcd" == render("{% echo a %}", context)
+      assert "b" == render("{% echo a[0] %}", context)
+      assert "cd" == render("{% echo a[1] %}", context)
+      assert "c" == render("{% echo a[1][0] %}", context)
+      assert "" == render("{% echo a[2] %}", context)
+    end
+
+    test "wrong access to object and list fields" do
+      context =
+        Context.new(%{
+          "b" => %{"c" => 1}
+        })
+
+      assert "" == render("{% echo b[0] %}", context)
+    end
+
+    test "removes tail whitespace" do
+      assert "Hello" == render("{% echo 'Hello' -%} ")
+    end
+
+    test "removes leading whitespace" do
+      assert "Hello" == render(" {%- echo 'Hello' %}")
+    end
+  end
+
+  describe "render with filter" do
+    test "abs" do
+      assert "5" == render("{% echo -5 | abs %}")
+      assert "5" == render("{% echo -5 | abs | abs %}")
+    end
+
+    test "invalid filter" do
+      assert "-5" == render("{% echo -5 | bad_filter %}")
+    end
+  end
+
+  describe "dynamic fields" do
+    test "simple new field" do
+      context = Context.new(%{"message" => fn _ -> "hello world" end})
+      assert "hello world" == render("{% echo message %}", context)
+    end
+
+    test "dynamic field on parent object" do
+      context =
+        Context.new(%{
+          "message" => %{
+            "value" => "Hello World",
+            "calculated_value" => fn %{"value" => value} -> value end
+          }
+        })
+
+      assert "Hello World" == render("{% echo message.calculated_value %}", context)
+    end
+  end
+
+  describe "square brackets object access" do
+    test "simple field name" do
+      context =
+        Context.new(%{
+          "message" => %{"key" => "Hello World"}
+        })
+
+      assert "Hello World" == render("{% echo message['key'] %}", context)
+      assert "Hello World" == render("{% echo message[\"key\"] %}", context)
+    end
+
+    test "field name from context" do
+      context =
+        Context.new(%{
+          "keyvar" => "key",
+          "message" => %{
+            "key" => "Hello World"
+          }
+        })
+
+      assert "Hello World" == render("{% echo message[keyvar] %}", context)
+    end
+
+    test "field name from variable" do
+      context =
+        Context.new(%{
+          "message" => %{
+            "map" => %{"key" => "Hello World"}
+          }
+        })
+
+      assert "Hello World" ==
+               render(
+                 "{% assign mapvar = \"map\" %}{% assign keyvar = \"key\" %}{% echo message[mapvar][keyvar] %}",
+                 context
+               )
+    end
+  end
+
+  def render(doc, context \\ %Context{}) do
+    {:ok, parsed_doc, _, _, _, _} = Base.parse(doc)
+
+    {result, _} = Liquex.render(parsed_doc, context)
+
+    result |> to_string()
+  end
+end

--- a/test/liquex/tag/echo_tag_test.exs
+++ b/test/liquex/tag/echo_tag_test.exs
@@ -110,8 +110,12 @@ defmodule Liquex.Tag.EchoTagTest do
       assert "5" == render("{% echo 5 %}")
       assert "5" == render("{% liquid echo 5 %}")
       assert "Hello" == render("{% echo 'Hello' %}")
+      assert "Hello" == render("{% liquid echo 'Hello' %}")
       assert "true" == render("{% echo true %}")
+      assert "true" == render("{% liquid echo true %}")
       assert "" == render("{% echo nil %}")
+      assert "" == render("{% liquid echo nil %}")
+      assert "55" == render("{% liquid echo 5\necho 5 %}")
     end
 
     test "simple fields" do

--- a/test/liquex/tag/for_tag_test.exs
+++ b/test/liquex/tag/for_tag_test.exs
@@ -124,21 +124,25 @@ defmodule Liquex.Tag.ForTagTest do
           }
         })
 
-      {:ok, template} =
-        """
-        {% for product in collection.products %}
-          {{ product.title }}
-        {% endfor %}
-        """
-        |> String.trim()
-        |> Liquex.parse()
-
-      assert Liquex.render(template, context)
-             |> elem(0)
-             |> to_string()
-             |> String.trim()
+      assert render(
+               """
+               {% for product in collection.products %}
+                 {{ product.title }}
+               {% endfor %}
+               """,
+               context
+             )
              |> String.split("\n")
              |> trim_list() == ["hat", "shirt", "pants"]
+
+      assert render(
+               """
+               {% liquid for product in collection.products
+                 echo product.title
+               endfor %}
+               """,
+               context
+             ) == "hatshirtpants"
     end
 
     test "render loop with limit" do
@@ -159,6 +163,15 @@ defmodule Liquex.Tag.ForTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(1 2)
+
+      assert render(
+               """
+               {% liquid for item in array limit:2
+                 echo item
+               endfor %}
+               """,
+               context
+             ) == "12"
     end
 
     test "render loop with offset" do
@@ -179,6 +192,15 @@ defmodule Liquex.Tag.ForTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(3 4 5 6)
+
+      assert render(
+               """
+               {% liquid for item in array offset:2
+                 echo item
+               endfor %}
+               """,
+               context
+             ) == "3456"
     end
 
     test "render loop with reverse" do
@@ -199,6 +221,15 @@ defmodule Liquex.Tag.ForTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(6 5 4 3 2 1)
+
+      assert render(
+               """
+               {% liquid for item in array reversed
+                 echo item
+               endfor %}
+               """,
+               context
+             ) == "654321"
     end
 
     test "render loop with all the things" do
@@ -219,6 +250,15 @@ defmodule Liquex.Tag.ForTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(5)
+
+      assert render(
+               """
+               {% liquid for item in array reversed limit:2 offset:1
+                 echo item
+               endfor %}
+               """,
+               context
+             ) == "5"
     end
 
     test "render loop with range" do
@@ -237,6 +277,15 @@ defmodule Liquex.Tag.ForTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(3 4 5)
+
+      assert render(
+               """
+               {% liquid for i in (3..5)
+                 echo i
+               endfor %}
+               """,
+               Context.new(%{})
+             ) == "345"
     end
 
     test "render loop with range w/ field" do
@@ -249,12 +298,23 @@ defmodule Liquex.Tag.ForTagTest do
         |> String.trim()
         |> Liquex.parse()
 
-      assert Liquex.render(template, Context.new(%{"num" => 4}))
+      context = Context.new(%{"num" => 4})
+
+      assert Liquex.render(template, context)
              |> elem(0)
              |> to_string()
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(1 2 3 4)
+
+      assert render(
+               """
+               {% liquid for i in (1..num)
+                echo i
+               endfor %}
+               """,
+               context
+             ) == "1234"
     end
 
     test "render for loop with forloop variable" do
@@ -279,6 +339,21 @@ defmodule Liquex.Tag.ForTagTest do
              |> String.trim()
              |> String.split("\n")
              |> trim_list() == ~w(true 1 0 false 3 3 2 false 2 1 false 3 2 1 false 3 2 true 3 1 0)
+
+      assert render(
+               """
+               {% liquid for i in (1..3)
+                 echo forloop.first
+                 echo forloop.index
+                 echo forloop.index0
+                 echo forloop.last
+                 echo forloop.length
+                 echo forloop.rindex
+                 echo forloop.rindex0
+               endfor %}
+               """,
+               Context.new(%{})
+             ) == "true10false332false21false321false32true310"
     end
 
     test "follows scoping rules" do
@@ -298,6 +373,16 @@ defmodule Liquex.Tag.ForTagTest do
              |> elem(0)
              |> to_string()
              |> String.trim() == "inner"
+
+      assert render("""
+             {% liquid
+              assign x = "outer"
+              for i in (1..1)
+                assign x = "inner"
+              endfor
+
+              echo x %}
+             """) == "inner"
     end
   end
 

--- a/test/liquex/tag/if_tag_test.exs
+++ b/test/liquex/tag/if_tag_test.exs
@@ -268,4 +268,80 @@ defmodule Liquex.Tag.IfTagTest do
                "It's true"
     end
   end
+
+  describe "render in liquid tag" do
+    test "failing if statement" do
+      context = Context.new(%{"product" => %{"title" => "Not Awesome Shoes"}})
+
+      assert render(
+               """
+               {% liquid if product.title == "Awesome Shoes"
+                  echo "These shoes are awesome!"
+               endif %}
+               """,
+               context
+             ) == ""
+    end
+
+    test "else statement" do
+      context = Context.new(%{"product" => %{"title" => "Not Awesome Shoes"}})
+
+      assert render(
+               """
+               {% liquid if product.title == "Awesome Shoes"
+                 echo "These shoes are awesome!"
+               else
+                 echo "These are Not Awesome Shoes"
+               endif %}
+               """,
+               context
+             ) ==
+               "These are Not Awesome Shoes"
+    end
+
+    test "elsif statement" do
+      context = Context.new(%{"product" => %{"id" => 2, "title" => "Not Awesome Shoes"}})
+
+      assert render(
+               """
+               {% liquid if product.title == "Awesome Shoes"
+                 echo "These shoes are awesome!"
+               elsif product.id == 2
+                 echo "These are not awesome shoes"
+               else
+                 echo "I don't know what these are"
+               endif %}
+               """,
+               context
+             ) == "These are not awesome shoes"
+    end
+
+    test "or statement" do
+      customer = %{"tags" => [], "email" => "example@mycompany.com"}
+
+      assert render(
+               """
+               {% liquid if customer.tags contains 'VIP' or customer.email contains 'mycompany.com'
+                 echo "Welcome! We're pleased to offer you a special discount of 15% on all products."
+               else
+                 echo "Welcome to our store!"
+               endif %}
+               """,
+               Context.new(%{customer: customer})
+             ) == "Welcome! We're pleased to offer you a special discount of 15% on all products."
+    end
+
+    test "mixed or/and statement" do
+      assert render(
+               """
+               {% liquid if true and false or true
+                 echo "It's true"
+               else
+                 echo "It's not true"
+               endif %}
+               """,
+               Context.new(%{})
+             ) == "It's true"
+    end
+  end
 end

--- a/test/liquex/tag/increment_tag_test.exs
+++ b/test/liquex/tag/increment_tag_test.exs
@@ -36,6 +36,19 @@ defmodule Liquex.Tag.IncrementTagTest do
              |> elem(0)
              |> to_string()
              |> String.trim() == "10\n11\n12\n0\n1"
+
+      assert render(
+               """
+                 {% liquid
+                   increment a
+                   increment a
+                   increment a
+                   increment b
+                   increment b
+                 %}
+               """,
+               Liquex.Context.new(%{a: 10})
+             ) == "10111201"
     end
 
     test "increments default key" do
@@ -48,6 +61,13 @@ defmodule Liquex.Tag.IncrementTagTest do
              |> elem(0)
              |> to_string()
              |> String.trim() == "0 1 2"
+
+      assert render("""
+               {% liquid
+                 increment
+                 increment
+                 increment %}
+             """) == "012"
     end
 
     test "decrement from default key" do
@@ -60,6 +80,13 @@ defmodule Liquex.Tag.IncrementTagTest do
              |> elem(0)
              |> to_string()
              |> String.trim() == "-1 -2 -3"
+
+      assert render("""
+               {% liquid
+                 decrement
+                 decrement
+                 decrement %}
+             """) == "-1-2-3"
     end
 
     test "decrements value" do
@@ -79,6 +106,20 @@ defmodule Liquex.Tag.IncrementTagTest do
              |> elem(0)
              |> to_string()
              |> String.trim() == "10\n9\n8\n-1\n-2"
+
+      assert render(
+               """
+                {% liquid
+                  assign a = 0
+                  decrement a
+                  decrement a
+                  decrement a
+                  decrement b
+                  decrement b
+                %}
+               """,
+               Liquex.Context.new(%{a: 10})
+             ) == "1098-1-2"
     end
   end
 end

--- a/test/liquex/tag/object_tag_test.exs
+++ b/test/liquex/tag/object_tag_test.exs
@@ -3,7 +3,6 @@ defmodule Liquex.Tag.ObjectTagTest do
   import Liquex.TestHelpers
 
   alias Liquex.Context
-  alias Liquex.Parser.Base
 
   describe "parse" do
     test "handles simple filter" do
@@ -214,13 +213,5 @@ defmodule Liquex.Tag.ObjectTagTest do
                  context
                )
     end
-  end
-
-  def render(doc, context \\ %Context{}) do
-    {:ok, parsed_doc, _, _, _, _} = Base.parse(doc)
-
-    {result, _} = Liquex.render(parsed_doc, context)
-
-    result |> to_string()
   end
 end

--- a/test/liquex/tag/render_tag_test.exs
+++ b/test/liquex/tag/render_tag_test.exs
@@ -177,6 +177,15 @@ defmodule Liquex.Tag.RenderTagTest do
 
       assert render_with_files("{% if true %}{% render 'snippet' %}{% endif %}", files) ==
                "my message"
+
+      assert render_with_files(
+               """
+               {% liquid if true
+                 render 'snippet'
+               endif %}
+               """,
+               files
+             ) == "my message"
     end
 
     test "break through render" do

--- a/test/liquex/tag/render_tag_test.exs
+++ b/test/liquex/tag/render_tag_test.exs
@@ -82,7 +82,7 @@ defmodule Liquex.Tag.RenderTagTest do
     Liquex.Context.new(scope, file_system: MockFileSystem.new(files))
   end
 
-  def render(template, files, scope \\ %{}) do
+  def render_with_files(template, files, scope \\ %{}) do
     {:ok, template} = Liquex.parse(template)
 
     Liquex.render(template, context(files, scope))
@@ -93,14 +93,14 @@ defmodule Liquex.Tag.RenderTagTest do
 
   describe "render" do
     test "renders external template" do
-      assert render("{% render 'source' %}", %{"source" => "rendered content"}) ==
+      assert render_with_files("{% render 'source' %}", %{"source" => "rendered content"}) ==
                "rendered content"
     end
 
     test "render passes named arguments into inner scope" do
       files = %{"product" => "{{ inner_product.title }}"}
 
-      assert render("{% render 'product', inner_product: outer_product %}", files, %{
+      assert render_with_files("{% render 'product', inner_product: outer_product %}", files, %{
                "outer_product" => %{"title" => "My Product"}
              }) == "My Product"
     end
@@ -108,7 +108,7 @@ defmodule Liquex.Tag.RenderTagTest do
     test "render does not pass outer scope arguments into inner scope" do
       files = %{"snippet" => "{{ outer_variable }}"}
 
-      assert render(
+      assert render_with_files(
                "{% assign outer_variable = 'should not be visible' %}{% render 'snippet' %}",
                files
              ) == ""
@@ -117,30 +117,33 @@ defmodule Liquex.Tag.RenderTagTest do
     test "render accepts literals as arguments" do
       files = %{"snippet" => "{{ price }}"}
 
-      assert render("{% render 'snippet', price: 123 %}", files) == "123"
+      assert render_with_files("{% render 'snippet', price: 123 %}", files) == "123"
     end
 
     test "render accepts multiple named arguments" do
       files = %{"snippet" => "{{ one }} {{ two }}"}
 
-      assert render("{% render 'snippet', one: 1, two: 2 %}", files) == "1 2"
+      assert render_with_files("{% render 'snippet', one: 1, two: 2 %}", files) == "1 2"
     end
 
     test "render does not inherit variable with same name as snippet" do
       files = %{"snippet" => "{{ snippet }}"}
 
-      assert render("{% assign snippet = 'should not be visible' %}{% render 'snippet' %}", files) ==
+      assert render_with_files(
+               "{% assign snippet = 'should not be visible' %}{% render 'snippet' %}",
+               files
+             ) ==
                ""
     end
 
     test "render does not mutate parent scope" do
       files = %{"snippet" => "{% assign inner = 1 %}"}
-      assert render("{% render 'snippet' %}{{ inner }}", files) == ""
+      assert render_with_files("{% render 'snippet' %}{{ inner }}", files) == ""
     end
 
     test "render handles nested render tags" do
       files = %{"one" => "one {% render 'two' %}", "two" => "two"}
-      assert render("{% render 'one' %}", files) == "one two"
+      assert render_with_files("{% render 'one' %}", files) == "one two"
     end
 
     test "render allows access to static environment" do
@@ -171,27 +174,38 @@ defmodule Liquex.Tag.RenderTagTest do
 
     test "render tag within if statement" do
       files = %{"snippet" => "my message"}
-      assert render("{% if true %}{% render 'snippet' %}{% endif %}", files) == "my message"
+
+      assert render_with_files("{% if true %}{% render 'snippet' %}{% endif %}", files) ==
+               "my message"
     end
 
     test "break through render" do
       files = %{"break" => "{% break %}"}
-      assert render("{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}", files) == "1"
 
-      assert render("{% for i in (1..3) %}{{ i }}{% render 'break' %}{{ i }}{% endfor %}", files) ==
+      assert render_with_files(
+               "{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}",
+               files
+             ) == "1"
+
+      assert render_with_files(
+               "{% for i in (1..3) %}{{ i }}{% render 'break' %}{{ i }}{% endfor %}",
+               files
+             ) ==
                "112233"
     end
 
     test "increment is isolated between renders" do
       files = %{"incr" => "{% increment %}"}
 
-      assert render("{% increment %}{% increment %}{% render 'incr' %}", files) == "010"
+      assert render_with_files("{% increment %}{% increment %}{% render 'incr' %}", files) ==
+               "010"
     end
 
     test "decrement is isolated between renders" do
       files = %{"decr" => "{% decrement %}"}
 
-      assert render("{% decrement %}{% decrement %}{% render 'decr' %}", files) == "-1-2-1"
+      assert render_with_files("{% decrement %}{% decrement %}{% render 'decr' %}", files) ==
+               "-1-2-1"
     end
   end
 
@@ -199,7 +213,7 @@ defmodule Liquex.Tag.RenderTagTest do
     test "render tag with" do
       files = %{"product" => "Product: {{ product.title }}"}
 
-      assert render("{% render 'product' with products[0] %}", files, %{
+      assert render_with_files("{% render 'product' with products[0] %}", files, %{
                "products" => [%{"title" => "Draft 151cm"}, %{"title" => "Element 155cm"}]
              }) == "Product: Draft 151cm"
     end
@@ -207,9 +221,13 @@ defmodule Liquex.Tag.RenderTagTest do
     test "render tag with alias" do
       files = %{"product_alias" => "Product: {{ product.title }}"}
 
-      assert render("{% render 'product_alias' with products[0] as product %}", files, %{
-               "products" => [%{"title" => "Draft 151cm"}, %{"title" => "Element 155cm"}]
-             }) == "Product: Draft 151cm"
+      assert render_with_files(
+               "{% render 'product_alias' with products[0] as product %}",
+               files,
+               %{
+                 "products" => [%{"title" => "Draft 151cm"}, %{"title" => "Element 155cm"}]
+               }
+             ) == "Product: Draft 151cm"
     end
   end
 
@@ -217,7 +235,7 @@ defmodule Liquex.Tag.RenderTagTest do
     test "render tag with for" do
       files = %{"product" => "Product: {{ product.title }} "}
 
-      assert render("{% render 'product' for products %}", files, %{
+      assert render_with_files("{% render 'product' for products %}", files, %{
                "products" => [%{"title" => "Draft 151cm"}, %{"title" => "Element 155cm"}]
              }) == "Product: Draft 151cm Product: Element 155cm"
     end
@@ -225,7 +243,7 @@ defmodule Liquex.Tag.RenderTagTest do
     test "render tag with for and alias" do
       files = %{"product_alias" => "Product: {{ product.title }} "}
 
-      assert render("{% render 'product_alias' for products as product %}", files, %{
+      assert render_with_files("{% render 'product_alias' for products as product %}", files, %{
                "products" => [%{"title" => "Draft 151cm"}, %{"title" => "Element 155cm"}]
              }) == "Product: Draft 151cm Product: Element 155cm"
     end
@@ -236,7 +254,7 @@ defmodule Liquex.Tag.RenderTagTest do
           "Product: {{ product.title }} {% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %} index:{{ forloop.index }} "
       }
 
-      assert render("{% render 'product' for products %}", files, %{
+      assert render_with_files("{% render 'product' for products %}", files, %{
                "products" => [%{"title" => "Draft 151cm"}, %{"title" => "Element 155cm"}]
              }) == "Product: Draft 151cm first  index:1 Product: Element 155cm  last index:2"
     end

--- a/test/liquex/tag/tablerow_tag_test.exs
+++ b/test/liquex/tag/tablerow_tag_test.exs
@@ -45,7 +45,9 @@ defmodule Liquex.Tag.TablerowTagTest do
         |> String.trim()
         |> Liquex.parse()
 
-      assert Liquex.render(template, Context.new(%{"collection" => [1, 2, 3]}))
+      context = Context.new(%{"collection" => [1, 2, 3]})
+
+      assert Liquex.render(template, context)
              |> elem(0)
              |> to_string()
              |> String.trim()
@@ -53,6 +55,15 @@ defmodule Liquex.Tag.TablerowTagTest do
              |> trim_list()
              |> Enum.join() ==
                "<table><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></table>"
+
+      assert render(
+               """
+                 <table>{% liquid tablerow product in collection
+                   echo product
+                 endtablerow %}</table>
+               """,
+               context
+             ) == "<table><tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></table>"
     end
 
     test "tablerow with cols" do
@@ -67,7 +78,9 @@ defmodule Liquex.Tag.TablerowTagTest do
         |> String.trim()
         |> Liquex.parse()
 
-      assert Liquex.render(template, Context.new(%{"collection" => [1, 2, 3]}))
+      context = Context.new(%{"collection" => [1, 2, 3]})
+
+      assert Liquex.render(template, context)
              |> elem(0)
              |> to_string()
              |> String.trim()
@@ -75,6 +88,15 @@ defmodule Liquex.Tag.TablerowTagTest do
              |> trim_list()
              |> Enum.join() ==
                "<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td></td></tr></table>"
+
+      assert render(
+               """
+                 <table>{% liquid tablerow product in collection cols:2
+                   echo product
+                 endtablerow %}</table>
+               """,
+               context
+             ) == "<table><tr><td>1</td><td>2</td></tr><tr><td>3</td><td></td></tr></table>"
     end
   end
 

--- a/test/liquex/tag/unless_tag_test.exs
+++ b/test/liquex/tag/unless_tag_test.exs
@@ -133,4 +133,32 @@ defmodule Liquex.Tag.UnlessTagTest do
              |> String.trim() == "These shoes are not awesome."
     end
   end
+
+  describe "render within liquid tag" do
+    test "simple unless" do
+      {:ok, template} =
+        """
+        {% liquid unless product.title == "Awesome Shoes"
+          echo "These shoes are not awesome."
+        else
+          echo "These shoes ARE awesome."
+        endunless %}
+        """
+        |> String.trim()
+        |> Liquex.parse()
+
+      assert Liquex.render(template, Context.new(%{"product" => %{"title" => "Awesome Shoes"}}))
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "These shoes ARE awesome."
+
+      assert Liquex.render(
+               template,
+               Context.new(%{"product" => %{"title" => "Not Awesome Shoes"}})
+             )
+             |> elem(0)
+             |> to_string()
+             |> String.trim() == "These shoes are not awesome."
+    end
+  end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -48,4 +48,11 @@ defmodule Liquex.TestHelpers do
 
   def liquid_render(liquid, json),
     do: System.cmd("ruby", ["test/render.rb", liquid, json])
+
+  def render(doc, context \\ %Liquex.Context{}) do
+    with {:ok, parsed_doc, _, _, _, _} <- Liquex.Parser.Base.parse(doc),
+         {result, _} = Liquex.render(parsed_doc, context) do
+      to_string(result)
+    end
+  end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -25,7 +25,7 @@ defmodule Liquex.TestHelpers do
       end
     else
       {:error, msg, _} ->
-        flunk("Unable to parse: #{msg}")
+        flunk("Unable to parse: #{msg} in file #{path}")
 
       {response, exit_code} when is_integer(exit_code) ->
         flunk("Unable to parse: '#{response}', exit code: #{exit_code}")

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -49,7 +49,7 @@ defmodule Liquex.TestHelpers do
   def liquid_render(liquid, json),
     do: System.cmd("ruby", ["test/render.rb", liquid, json])
 
-  def render(doc, context \\ %Liquex.Context{}) do
+  def render(doc, context \\ Liquex.Context.new(%{})) do
     with {:ok, parsed_doc, _, _, _, _} <- Liquex.Parser.Base.parse(doc),
          {result, _} = Liquex.render(parsed_doc, context) do
       to_string(result) |> String.trim()

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -52,7 +52,7 @@ defmodule Liquex.TestHelpers do
   def render(doc, context \\ %Liquex.Context{}) do
     with {:ok, parsed_doc, _, _, _, _} <- Liquex.Parser.Base.parse(doc),
          {result, _} = Liquex.render(parsed_doc, context) do
-      to_string(result)
+      to_string(result) |> String.trim()
     end
   end
 end


### PR DESCRIPTION
Add liquid tag support.

Support using the inline liquid tag to follow 5.0.0.

    {% liquid
      assign product_type = product.type | downcase
      assign message = '' | downcase
    
      case product_type
        when 'health'
          assign message = 'This is a health potion!'
        when 'love'
          assign message = 'This is a love potion!'
        else
          assign message = 'This is a potion!'
      endcase
    
      echo message
    %}