### PR TITLE
some additional Liquid gem compatibility

### DIFF
--- a/lib/liquex/argument.ex
+++ b/lib/liquex/argument.ex
@@ -43,6 +43,12 @@ defmodule Liquex.Argument do
   end
 
   # Special case ".size"
+  defp do_eval(value, [{:key, "size"} | tail], context) when is_binary(value) do
+    value
+    |> String.length()
+    |> do_eval(tail, context)
+  end
+
   defp do_eval(value, [{:key, "size"} | tail], context) when is_list(value) do
     value
     |> length()

--- a/lib/liquex/filter.ex
+++ b/lib/liquex/filter.ex
@@ -175,6 +175,7 @@ defmodule Liquex.Filter do
 
   def ceil(value, _) when is_float(value), do: Float.ceil(value) |> trunc()
   def ceil(value, _) when is_integer(value), do: value
+  def ceil(nil, _), do: 0
 
   @doc """
   Removes any nil values from an array.
@@ -842,6 +843,8 @@ defmodule Liquex.Filter do
 
   defp to_number(value, allow_conversion_to_zero \\ true)
   defp to_number(value, _) when is_number(value), do: value
+  defp to_number(nil, true), do: 0
+  defp to_number(nil, false), do: nil
 
   defp to_number(value, allow_conversion_to_zero) when is_binary(value) do
     case Integer.parse(value) do

--- a/lib/liquex/filter.ex
+++ b/lib/liquex/filter.ex
@@ -81,7 +81,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.abs("-1.1", %{})
       1.1
   """
-  @spec abs(String.t() | number, any) :: number
+  @spec abs(String.t() | number | nil, any) :: number
   def abs(value, _), do: abs(to_number(value))
 
   @doc """
@@ -165,7 +165,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.ceil("3.5", %{})
       4
   """
-  @spec ceil(number | String.t(), map()) :: number
+  @spec ceil(number | String.t() | nil, map()) :: number
   def ceil(value, _) when is_binary(value) do
     case Float.parse(value) do
       {num, ""} -> Float.ceil(num) |> trunc()
@@ -360,7 +360,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.floor(2.0, %{})
       2
   """
-  @spec floor(binary | number, any) :: integer
+  @spec floor(binary | number | nil, any) :: integer
   def floor(value, _) do
     value
     |> to_number()
@@ -425,7 +425,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.minus(183.357, 12, %{})
       171.357
   """
-  @spec minus(number, number, Context.t()) :: number
+  @spec minus(number | nil, number | nil, Context.t()) :: number
   def minus(left, right, _), do: to_number(left) - to_number(right)
 
   @doc """
@@ -439,7 +439,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.modulo(183.357, 12, %{})
       3.357
   """
-  @spec modulo(number, number, Context.t()) :: number
+  @spec modulo(number | nil, number | nil, Context.t()) :: number
   def modulo(left, right, _) do
     left = to_number(left)
     right = to_number(right)
@@ -473,6 +473,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.plus(183.357, 12, %{})
       195.357
   """
+  @spec plus(number | nil, number | nil, Context.t()) :: number
   def plus(left, right, _), do: to_number(left) + to_number(right)
 
   @doc """
@@ -558,7 +559,7 @@ defmodule Liquex.Filter do
       iex> Liquex.Filter.round(183.357, 2, %{})
       183.36
   """
-  @spec round(binary | number, binary | number, any) :: number
+  @spec round(binary | number | nil, binary | number | nil, any) :: number
   def round(value, precision \\ 0, context),
     do: do_round(to_number(value), to_number(precision, false), context)
 

--- a/lib/liquex/parser/field.ex
+++ b/lib/liquex/parser/field.ex
@@ -25,7 +25,7 @@ defmodule Liquex.Parser.Field do
   def identifier(combinator \\ empty()) do
     combinator
     |> utf8_string([?a..?z, ?A..?Z, ?_], 1)
-    |> concat(utf8_string([?a..?z, ?A..?Z, ?0..?9, ?_], min: 0))
+    |> concat(utf8_string([?a..?z, ?A..?Z, ?0..?9, ?_, ?-], min: 0))
     |> concat(optional(string("?")))
     |> reduce({Enum, :join, []})
   end

--- a/test/integration/cases/auto_convert_numbers.hrx
+++ b/test/integration/cases/auto_convert_numbers.hrx
@@ -1,11 +1,18 @@
 <===> auto_convert_numbers.liquid
-
+{% comment %} 'dummy' is an empty variable to compare math fns handling nil values {% endcomment %}
 {% comment %} Plus {% endcomment %}
 
 {{ '2' | plus: '7' }}
 {{ 2 | plus: '7' }}
 {{ '2' | plus: 7 }}
 {{ '2' | plus: 'a' }}
+{{ 'a' | plus: 'a' }}
+{{ dummy | plus: dummy }}
+{{ dummy | plus: 'a' }}
+{{ dummy | plus: '7' }}
+{{ 2 | plus: dummy }}
+{{ '2' | plus: dummy }}
+{{ 'a' | plus: dummy }}
 
 {% comment %} Minus {% endcomment %}
 
@@ -13,6 +20,13 @@
 {{ 2 | minus: '7' }}
 {{ '2' | minus: 7 }}
 {{ '2' | minus: 'a' }}
+{{ 'a' | minus: 'a' }}
+{{ dummy | minus: dummy }}
+{{ dummy | minus: 'a' }}
+{{ dummy | minus: '7' }}
+{{ 2 | minus: dummy }}
+{{ '2' | minus: dummy }}
+{{ 'a' | minus: dummy }}
 
 {% comment %} Times {% endcomment %}
 
@@ -20,6 +34,13 @@
 {{ 2 | times: '7' }}
 {{ '2' | times: 7 }}
 {{ '2' | times: 'a' }}
+{{ 'a' | times: 'a' }}
+{{ dummy | times: dummy }}
+{{ dummy | times: 'a' }}
+{{ dummy | times: '7' }}
+{{ 2 | times: dummy }}
+{{ '2' | times: dummy }}
+{{ 'a' | times: dummy }}
 
 {% comment %} Divided by {% endcomment %}
 
@@ -27,6 +48,13 @@
 {{ 10 | divided_by: '2' }}
 {{ '10' | divided_by: 2 }}
 {{ '10' | divided_by: 'a' }}
+{{ 'a' | divided_by: 'a' }}
+{{ dummy | divided_by: dummy }}
+{{ dummy | divided_by: 'a' }}
+{{ dummy | divided_by: '7' }}
+{{ 10 | divided_by: dummy }}
+{{ '10' | divided_by: dummy }}
+{{ 'a' | divided_by: dummy }}
 
 {% comment %} Ceil {% endcomment %}
 
@@ -34,6 +62,7 @@
 {{ 10.2 | ceil }}
 {{ '10.2' | ceil }}
 {{ 'a' | ceil }}
+{{ dummy | ceil }}
 
 {% comment %} Floor {% endcomment %}
 
@@ -41,6 +70,8 @@
 {{ 10.2 | floor }}
 {{ '10.2' | floor }}
 {{ 'a' | floor }}
+{{ dummy | floor }}
+
 
 {% comment %} Modulo {% endcomment %}
 
@@ -52,6 +83,13 @@
 {{ 10.2 | modulo: '3' }}
 {{ '10.2' | modulo: '3' }}
 {{ '10.2' | modulo: 'a' }}
+{{ 'a' | modulo: 'a' }}
+{{ dummy | modulo: dummy }}
+{{ dummy | modulo: 'a' }}
+{{ dummy | modulo: '7' }}
+{{ 10 | modulo: dummy }}
+{{ '10' | modulo: dummy }}
+{{ 'a' | modulo: dummy }}
 
 {% comment %} Round {% endcomment %}
 
@@ -64,10 +102,19 @@
 {{ 'a' | round: 1 }}
 {{ 10.201 | round: 'a' }}
 {{ 10.201 | round: -1 }}
+{{ 'a' | round: 'a' }}
+{{ dummy | round: dummy }}
+{{ dummy | round: 'a' }}
+{{ dummy | round: '-1' }}
+{{ 10 | round: dummy }}
+{{ 10.201 | round: dummy }}
+{{ '10' | round: dummy }}
+{{ 'a' | round: dummy }}
 
 {% comment %} abs {% endcomment %}
 
 {{ 10.2 | abs }}
-{{ '10.2' | abs}}
-{{ '-10.2' | abs}}
-{{ 'a' | abs}}
+{{ '10.2' | abs }}
+{{ '-10.2' | abs }}
+{{ 'a' | abs }}
+{{ dummy | abs }}

--- a/test/integration/cases/basic_object.hrx
+++ b/test/integration/cases/basic_object.hrx
@@ -8,6 +8,7 @@
   ],
   "object": {
     "field": "value",
+    "field-with-hyphens": "value2",
     "array": [
       4,
       5,
@@ -21,4 +22,4 @@ Hello {{ greeting }}
 
 Array: {{ array[1] }}
 
-Object: {{ object.field }} {{ object.array[2] }}
+Object: {{ object.field }} {{ object.array[2] }} {{ object.field-with-hyphens }}

--- a/test/integration/cases/special_case_fields.hrx
+++ b/test/integration/cases/special_case_fields.hrx
@@ -5,7 +5,8 @@
     "last": 2,
     "size": 3
   },
-  "b": [1, 2, 3]
+  "b": [1, 2, 3],
+  "c": "string"
 }
 
 <===> iteration.liquid
@@ -16,3 +17,5 @@
 {{ b.first }}
 {{ b.last }}
 {{ b.size }}
+
+{{ c.size }}

--- a/test/liquex/argument_test.exs
+++ b/test/liquex/argument_test.exs
@@ -45,6 +45,12 @@ defmodule Liquex.ArgumentTest do
       assert 5 == Argument.eval([field: [key: "field", key: "size"]], obj)
     end
 
+    test "evaluate with string.size" do
+      obj = Context.new(%{"field" => "String"})
+
+      assert 6 == Argument.eval([field: [key: "field", key: "size"]], obj)
+    end
+
     test "evaluate with out of bounds array field" do
       obj = Context.new(%{"field" => [%{}, %{"child" => 5}]})
 

--- a/test/liquex/argument_test.exs
+++ b/test/liquex/argument_test.exs
@@ -11,7 +11,7 @@ defmodule Liquex.ArgumentTest do
       assert 5 == Argument.eval([literal: 5], Context.new(%{}))
     end
 
-    test "evaluate unkown field" do
+    test "evaluate unknown field" do
       assert nil == Argument.eval([field: [key: "i"]], Context.new(%{}))
       assert nil == Argument.eval([field: [key: "a", key: "b"]], Context.new(%{}))
     end
@@ -37,6 +37,12 @@ defmodule Liquex.ArgumentTest do
       obj = Context.new(%{"field" => [%{"child" => 5}]})
 
       assert 5 == Argument.eval([field: [key: "field", key: "first", key: "child"]], obj)
+    end
+
+    test "evaluate with array.last" do
+      obj = Context.new(%{"field" => [1, 2, 3, 4, 5]})
+
+      assert 5 == Argument.eval([field: [key: "field", key: "last"]], obj)
     end
 
     test "evaluate with array.size" do

--- a/test/liquex/parser/field_test.exs
+++ b/test/liquex/parser/field_test.exs
@@ -23,6 +23,12 @@ defmodule Liquex.Parser.FieldTest do
     ])
   end
 
+  test "field with hyphens" do
+    assert_parse("{{ field-with-hyphens }}", [
+      {{:tag, Liquex.Tag.ObjectTag}, [field: [key: "field-with-hyphens"], filters: []]}
+    ])
+  end
+
   test "with accessors" do
     assert_parse(
       "{{ field[1] }}",


### PR DESCRIPTION
* Supports object fields with hyphens, tested compared to liquid gem
* Supports a string as input to .size , tested compared to liquid gem
* Supports  nil values when doing math, tested compared to liquid gem