### PR TITLE
Add parentheses to module_info

### DIFF
--- a/lib/liquex/indifferent.ex
+++ b/lib/liquex/indifferent.ex
@@ -182,7 +182,7 @@ defmodule Liquex.Indifferent do
   defp access(data, key), do: Access.fetch(data, key)
 
   defp implements_behaviour?(map, behaviour) when is_struct(map) do
-    map.__struct__.module_info[:attributes]
+    map.__struct__.module_info()[:attributes]
     |> Keyword.get(:behaviour, [])
     |> Enum.member?(behaviour)
   end


### PR DESCRIPTION
Silences Elixir 1.17 warning:

```
warning: using map.field notation (without parentheses) to invoke function Liquex.Context.module_info() is deprecated, you must add parentheses instead: remote.function()
  (liquex 0.13.0) lib/liquex/indifferent.ex:185: Liquex.Indifferent.implements_behaviour?/2
  (liquex 0.13.0) lib/liquex/indifferent.ex:175: Liquex.Indifferent.access/2
  (liquex 0.13.0) lib/liquex/indifferent.ex:97: Liquex.Indifferent.fetch/2
  (liquex 0.13.0) lib/liquex/indifferent.ex:38: Liquex.Indifferent.get/3
  (liquex 0.13.0) lib/liquex/argument.ex:60: Liquex.Argument.do_eval/3
  (liquex 0.13.0) lib/liquex/tag/object_tag.ex:111: Liquex.Tag.ObjectTag.render/2
  (liquex 0.13.0) lib/liquex/render.ex:25: Liquex.Render.render!/3
```